### PR TITLE
MR1: publish post 1 + landing infrastructure (series nav, /series, /tags)

### DIFF
--- a/src/components/SeriesNav.astro
+++ b/src/components/SeriesNav.astro
@@ -1,0 +1,121 @@
+---
+/**
+ * Bottom-of-post prev/next bar within a series. Auto-derived from the
+ * `series` + `series_order` fields on the published posts collection — no
+ * hand-curated `prev`/`next` schema field.
+ *
+ * Renders nothing if the post has no `series`, or if there are no
+ * neighbours yet (i.e. the series only has this one post published).
+ */
+import { getCollection } from 'astro:content';
+import { isPublished } from '../lib/posts';
+
+interface Props {
+  currentSlug: string;
+  series?: string;
+}
+const { currentSlug, series } = Astro.props;
+
+let prev: { slug: string; title: string; order?: number } | null = null;
+let next: { slug: string; title: string; order?: number } | null = null;
+
+if (series) {
+  const all = (await getCollection('posts', isPublished))
+    .filter((p) => p.data.series === series && typeof p.data.series_order === 'number')
+    .sort((a, b) => (a.data.series_order ?? 0) - (b.data.series_order ?? 0));
+  const i = all.findIndex((p) => p.slug === currentSlug);
+  if (i > 0) {
+    const p = all[i - 1];
+    prev = { slug: p.slug, title: p.data.title, order: p.data.series_order };
+  }
+  if (i >= 0 && i < all.length - 1) {
+    const n = all[i + 1];
+    next = { slug: n.slug, title: n.data.title, order: n.data.series_order };
+  }
+}
+---
+{(prev || next) && (
+  <nav class="series-nav" aria-label="Series navigation">
+    {prev ? (
+      <a class="series-nav__link series-nav__link--prev" href={`/posts/${prev.slug}/`}>
+        <span class="series-nav__direction">&larr; previous in series</span>
+        <span class="series-nav__title">
+          {prev.order != null && (
+            <span class="series-nav__num">{String(prev.order).padStart(2, '0')}</span>
+          )}
+          {prev.title}
+        </span>
+      </a>
+    ) : (
+      <span class="series-nav__link series-nav__link--placeholder" aria-hidden="true"></span>
+    )}
+    {next ? (
+      <a class="series-nav__link series-nav__link--next" href={`/posts/${next.slug}/`}>
+        <span class="series-nav__direction">next in series &rarr;</span>
+        <span class="series-nav__title">
+          {next.order != null && (
+            <span class="series-nav__num">{String(next.order).padStart(2, '0')}</span>
+          )}
+          {next.title}
+        </span>
+      </a>
+    ) : (
+      <span class="series-nav__link series-nav__link--placeholder" aria-hidden="true"></span>
+    )}
+  </nav>
+)}
+
+<style>
+  .series-nav {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin: 3rem 0 0;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--rule);
+  }
+  @media (max-width: 640px) {
+    .series-nav { grid-template-columns: 1fr; }
+  }
+  .series-nav__link {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    padding: 1rem 1.1rem;
+    background: var(--paper-2);
+    border: 1px solid var(--rule);
+    border-left: 3px solid var(--orange);
+    text-decoration: none;
+    color: var(--ink);
+    transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+    min-width: 0;
+  }
+  .series-nav__link--placeholder {
+    background: transparent;
+    border: 1px dashed var(--rule);
+    border-left: 3px dashed var(--rule);
+    pointer-events: none;
+  }
+  .series-nav__link--next { text-align: right; align-items: flex-end; }
+  .series-nav__link:hover { transform: translateY(-1px); background: var(--paper); border-color: var(--orange); color: var(--ink); }
+  .series-nav__direction {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+    color: var(--orange);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+  .series-nav__title {
+    font-family: 'Quicksand', system-ui, sans-serif;
+    font-weight: 600;
+    font-size: 1rem;
+    line-height: 1.25;
+    color: var(--ink);
+  }
+  .series-nav__num {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.78rem;
+    color: var(--ink-muted);
+    margin-right: 0.4rem;
+  }
+</style>

--- a/src/content/posts/2026-04-26-why-cpp26-reflection-matters.mdx
+++ b/src/content/posts/2026-04-26-why-cpp26-reflection-matters.mdx
@@ -1,7 +1,7 @@
 ---
 title: "C++26 Reflection: What changes, and why it matters"
 slug: "why-cpp26-reflection-matters"
-pubDate: 2026-04-27
+pubDate: 2026-04-26
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-04-27-why-cpp26-reflection-matters.mdx
+++ b/src/content/posts/2026-04-27-why-cpp26-reflection-matters.mdx
@@ -10,7 +10,7 @@ series_order: 1
 audience: polyglot
 tags: [reflection, cpp26, motivation, p2996]
 summary: "Part 1 of the C++26 reflection series. A 40-line JSON serializer nobody could write in C++ before 2026 — plus the strategic story of why static reflection changes the ecosystem."
-draft: true
+draft: false
 ---
 
 import GodboltEmbed from '../../components/GodboltEmbed.astro';
@@ -192,7 +192,7 @@ Among the mainstream languages with large ecosystems — Rust, Java, C#, Go, Pyt
 
 (Languages like D and Zig have had compile-time reflection for a while; the point isn't that C++ is first, but that among the languages C++ shares a developer pool with, it finally catches up — and in doing so gets a design with the benefit of watching everyone else for twenty years.)
 
-And because the reflection walk is just code — not a sealed macro — it composes with everything else the language offers. Annotations (`[[=rserial::json_name("user_name")]]`, `[[=rserial::skip{}]]`, `[[=rserial::rename_all(camel_case)]]`) port the serde / Jackson attribute vocabulary to C++ as plain values queryable at compile time. The format is a pluggable policy: the *same* annotated struct compiles down to JSON, YAML, XML, or anything else you can describe — one policy struct per format, zero shared runtime metadata. Post 9 explores the annotation design in depth; [post 11](/posts/one-codegen-many-formats/) unpacks the format-policy factoring.
+And because the reflection walk is just code — not a sealed macro — it composes with everything else the language offers. Annotations (`[[=rserial::json_name("user_name")]]`, `[[=rserial::skip{}]]`, `[[=rserial::rename_all(camel_case)]]`) port the serde / Jackson attribute vocabulary to C++ as plain values queryable at compile time. The format is a pluggable policy: the *same* annotated struct compiles down to JSON, YAML, XML, or anything else you can describe — one policy struct per format, zero shared runtime metadata. Both threads — annotations as values, formats as policies — get their own deep dive later in the series.
 
 ## Why this matters for the C++ community
 
@@ -224,8 +224,8 @@ The peel-first variant from the sidebar is in the same folder: replace `teaser` 
 
 ## What's next
 
-- **Post 2 — Your first `^^`: reflecting types, walking members** (coming soon) — the hands-on foundations. We take the teaser apart and rebuild it from primitives.
-- **Post 8 — A 40-line JSON serializer** — we revisit the teaser, scale it properly, and turn it into a real `lib/reflect_json`.
-- **[Post 11 — One codegen, many wire formats](/posts/one-codegen-many-formats/)** — JSON, YAML, XML from the same annotated struct.
+This is part 1 of a multi-post series. The next instalments take this teaser apart and rebuild it from primitives — `^^`, splicing, `template for`, then the everyday wins (enum names, `std::formatter`, hashing) and the bigger compositions (a real JSON serializer, annotations, multi-format codegen, a tiny ORM, a DI container, auto-generated mocks).
+
+The full plan, with publication dates, lives on the [`cpp26-reflection` series page](/series/cpp26-reflection/). Each post lands as it ships.
 
 Questions, corrections, or your own reflection war stories: drop them on [Slack](https://wrocpp.slack.com) or in the [GitHub Discussions](https://github.com/wrocpp/wrocpp.github.io/discussions) for this post.

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,6 +1,8 @@
 ---
 import BaseLayout from './BaseLayout.astro';
+import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
+import SeriesNav from '../components/SeriesNav.astro';
 
 interface Props {
   post: CollectionEntry<'posts'>;
@@ -9,7 +11,16 @@ const { post } = Astro.props;
 const { title, summary, pubDate, updatedDate, language, tags, series, series_order, audience, kind, draft } =
   post.data;
 const date = pubDate.toISOString().slice(0, 10);
-const seriesTotal = series === 'cpp26-reflection' ? 18 : undefined;
+
+// Series total is derived from the maximum `series_order` across ALL posts in
+// the collection (drafts included), not from `getCollection(..., isPublished)`
+// — otherwise the "part 02 / 02" indicator would shrink as posts ship and
+// readers would lose the sense of how long the series will eventually be.
+const seriesTotal = series
+  ? (await getCollection('posts'))
+      .filter((p) => p.data.series === series && typeof p.data.series_order === 'number')
+      .reduce((max, p) => Math.max(max, p.data.series_order ?? 0), 0) || undefined
+  : undefined;
 const progressPct =
   seriesTotal && series_order ? Math.round((series_order / seriesTotal) * 100) : 0;
 ---
@@ -76,6 +87,8 @@ const progressPct =
       <div class="prose reveal reveal-2">
         <slot />
       </div>
+
+      <SeriesNav currentSlug={post.slug} series={series} />
     </div>
   </article>
 </BaseLayout>

--- a/src/pages/series/[series].astro
+++ b/src/pages/series/[series].astro
@@ -1,0 +1,53 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PostCard from '../../components/PostCard.astro';
+import { getCollection } from 'astro:content';
+import { isPublished } from '../../lib/posts';
+import type { GetStaticPaths } from 'astro';
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  // Build a static path per distinct `series` slug. Drafts contribute their
+  // series too — otherwise a brand-new series whose first post hasn't shipped
+  // yet would 404 in dev. The post LIST inside the page is still gated by
+  // `isPublished`, so the production page only renders shipped posts.
+  const all = await getCollection('posts');
+  const seen = new Set<string>();
+  for (const p of all) if (p.data.series) seen.add(p.data.series);
+  return Array.from(seen).map((series) => ({ params: { series } }));
+};
+
+const { series } = Astro.params;
+const all = await getCollection('posts', isPublished);
+const inSeries = all
+  .filter((p) => p.data.series === series && typeof p.data.series_order === 'number')
+  .sort((a, b) => (a.data.series_order ?? 0) - (b.data.series_order ?? 0));
+
+const seriesTotal = (await getCollection('posts'))
+  .filter((p) => p.data.series === series && typeof p.data.series_order === 'number')
+  .reduce((max, p) => Math.max(max, p.data.series_order ?? 0), 0) || inSeries.length;
+
+const title = `series · ${series}`;
+---
+<BaseLayout title={`${title} — wro.cpp`} description={`All posts in the ${series} series.`} canonicalPath={`/series/${series}/`}>
+  <section class="wrap">
+    <header class="page-head">
+      <div class="page-head__eyebrow">// series</div>
+      <h1 class="page-head__title">{series}</h1>
+      <p class="page-head__sub">
+        Part of the wro.cpp <code>{series}</code> series — {inSeries.length} of {seriesTotal} posts published so far.
+      </p>
+    </header>
+
+    {inSeries.length === 0 ? (
+      <p style="font-family:'JetBrains Mono',monospace;color:var(--ink-muted);">
+        No posts published in this series yet. Check back soon.
+      </p>
+    ) : (
+      <ul class="card-grid" role="list" style="list-style:none;padding:0;">
+        {inSeries.map((p) => (
+          <li><PostCard post={p} /></li>
+        ))}
+      </ul>
+    )}
+  </section>
+</BaseLayout>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,0 +1,43 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PostCard from '../../components/PostCard.astro';
+import { getCollection } from 'astro:content';
+import { isPublished, byDateDesc } from '../../lib/posts';
+import type { GetStaticPaths } from 'astro';
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  // Generate a path per distinct tag across ALL posts (drafts included) so
+  // tag links rendered on draft posts in dev never 404. The page body is
+  // still gated by `isPublished`.
+  const all = await getCollection('posts');
+  const seen = new Set<string>();
+  for (const p of all) for (const t of p.data.tags ?? []) seen.add(t);
+  return Array.from(seen).map((tag) => ({ params: { tag } }));
+};
+
+const { tag } = Astro.params;
+const posts = (await getCollection('posts', isPublished))
+  .filter((p) => (p.data.tags ?? []).includes(tag))
+  .sort(byDateDesc);
+---
+<BaseLayout title={`#${tag} — wro.cpp`} description={`Posts tagged #${tag} on wro.cpp.`} canonicalPath={`/tags/${tag}/`}>
+  <section class="wrap">
+    <header class="page-head">
+      <div class="page-head__eyebrow">// tag</div>
+      <h1 class="page-head__title">#{tag}</h1>
+      <p class="page-head__sub">{posts.length} {posts.length === 1 ? 'post' : 'posts'} tagged <code>#{tag}</code>.</p>
+    </header>
+
+    {posts.length === 0 ? (
+      <p style="font-family:'JetBrains Mono',monospace;color:var(--ink-muted);">
+        Nothing tagged #{tag} has shipped yet.
+      </p>
+    ) : (
+      <ul class="card-grid" role="list" style="list-style:none;padding:0;">
+        {posts.map((p) => (
+          <li><PostCard post={p} /></li>
+        ))}
+      </ul>
+    )}
+  </section>
+</BaseLayout>


### PR DESCRIPTION
## Summary

Ships the first post in the C++26 reflection series and adds the cross-cutting infrastructure every following per-post MR depends on.

Three atomic commits:

1. **feat(layout)** -- Dynamic ` + "`seriesTotal`" + ` (no more hard-coded 18) and a new ` + "`SeriesNav`" + ` component that renders a prev/next bar at the bottom of each post, derived from ` + "`series`" + ` + ` + "`series_order`" + ` and gated by ` + "`isPublished`" + ` so production never links to unshipped posts.
2. **feat(routes)** -- ` + "`/series/[series]/`" + ` and ` + "`/tags/[tag]/`" + ` dynamic indexes. Both were already linked from PostLayout but had no route handler, so every published post would have produced at least two 404s.
3. **docs(post-1)** -- Flips post 1 to ` + "`draft: false`" + ` and strips its three forward references to posts 8/9/11 (replaced with a single line pointing to the series page). The publish itself happens automatically via the daily cron build at 07:00 UTC on Monday 2026-04-27.

## What goes live, and when

- ` + "`pubDate: 2026-04-27`" + ` on post 1, ` + "`draft: false`" + `. After this MR merges, the post is still invisible in production until the daily cron runs on 2026-04-27 (or until you trigger ` + "`workflow_dispatch`" + ` manually).
- All other posts stay ` + "`draft: true`" + `; each will get its own MR.

## Verification done locally

- ` + "`NODE_ENV=production npm run build`" + `: 91 pages, no warnings (post 1's HTML isn't generated yet because its pubDate is tomorrow -- that's the correct production behaviour).
- ` + "`npm run dev`" + ` (where ` + "`isPublished`" + ` returns ` + "`true`" + ` for everything):
  - GET /posts/why-cpp26-reflection-matters/ -> 200, includes ` + "`series-nav`" + `, no leftover ` + "`post 8` / `post 11` / `one-codegen-many-formats`" + ` strings.
  - GET /series/cpp26-reflection/ -> 200, lists the series.
  - GET /tags/reflection/ -> 200.

## Test plan

- [ ] Merge.
- [ ] Verify the deploy.yml run is green and the new ` + "`/series/`" + ` and ` + "`/tags/`" + ` paths exist on prod (they have no posts yet because nothing's shipped).
- [ ] Wait for Monday 2026-04-27, ~07:00 UTC daily cron run.
- [ ] Reload https://wrocpp.github.io/posts/why-cpp26-reflection-matters/ -- should render with the SeriesNav (no prev or next yet, so nav element doesn't render at all).
- [ ] Visit /series/cpp26-reflection/ -- should list 1 post.
- [ ] Visit a tag link from post 1 (e.g. /tags/reflection/) -- should list 1 post.

## What this MR does NOT include (deferred)

- ` + "`scripts/shorten-examples.py`" + ` (planned for MR1 originally) -- post 1's permalinks already exist in ` + "`src/data/godbolt-permalinks.yml`" + `, so the script isn't strictly needed until MR2. Will land in the MR2 branch.