### PR TITLE
fix: point playground refs to cpp26-reflection-examples

### DIFF
--- a/src/components/GodboltEmbed.astro
+++ b/src/components/GodboltEmbed.astro
@@ -25,7 +25,7 @@ const {
   id,
   title = 'Run this example',
   subtitle = 'clang_bb_p2996 · -std=c++26 -freflection-latest -stdlib=libc++',
-  fallbackHref = 'https://github.com/wrocpp/cpp26-playground',
+  fallbackHref = 'https://github.com/wrocpp/cpp26-reflection-examples',
 } = Astro.props;
 
 const isPlaceholder = id.startsWith('TODO') || id === 'placeholder';

--- a/src/content/posts/2026-04-26-why-cpp26-reflection-matters.mdx
+++ b/src/content/posts/2026-04-26-why-cpp26-reflection-matters.mdx
@@ -210,7 +210,7 @@ None of this is automatic. P2996 is new. The implementations are experimental â€
 
 ## Try it
 
-All the examples from this post are runnable via a pinned `clang-p2996` Docker image in the [playground repo](https://github.com/wrocpp/cpp26-playground). From a checkout:
+All the examples from this post are runnable via a pinned `clang-p2996` Docker image in the [`cpp26-reflection-examples` repo](https://github.com/wrocpp/cpp26-reflection-examples). From a checkout:
 
 ```sh
 ./build.sh                                                 # one-time, ~30-60 min on arm64

--- a/src/content/posts/2027-01-06-reflect-llmschema.mdx
+++ b/src/content/posts/2027-01-06-reflect-llmschema.mdx
@@ -184,6 +184,6 @@ Status: v0.1.0 covers the MVP scope above. v0.2 roadmap: streaming tool-response
 ## What's next
 
 - **[Post 20 — reflect_arbitrary](/posts/reflect-arbitrary/)** — property-based test generators from types.
-- The playground example file exercises the type-mapping walk; see `posts/19-reflect-llmschema/examples/` in the [cpp26-playground repo](https://github.com/wrocpp/cpp26-playground).
+- The example file exercises the type-mapping walk; see `posts/19-reflect-llmschema/examples/` in the [`cpp26-reflection-examples` repo](https://github.com/wrocpp/cpp26-reflection-examples).
 
 Questions / corrections / your own MCP server use case: drop in [Discussions](https://github.com/wrocpp/wrocpp.github.io/discussions) or on [Slack](https://wrocpp.slack.com).

--- a/src/content/posts/2027-03-17-reflect-tracing.mdx
+++ b/src/content/posts/2027-03-17-reflect-tracing.mdx
@@ -163,7 +163,7 @@ All five emit a per-call-site register entry so the dump step can map key → di
 
 **For a mixed codebase**, `reflect_tracing` ships all of them and documents the trade-offs. Default is Form 1 (`scope_guard<^^Fn>`) because it's the only form that composes with the reflection-driven filter / arg-capture annotations coming in C++29 — but every form produces a valid trace, and picking the right one per function is a legitimate codebase-hygiene decision rather than a library constraint.
 
-The playground [`trace_emit.cpp`](https://github.com/wrocpp/cpp26-playground/blob/main/posts/24-reflect-tracing/examples/trace_emit.cpp) exercises all four forms side-by-side and shows the dump showing each one's resolved name.
+The example [`trace_emit.cpp`](https://github.com/wrocpp/cpp26-reflection-examples/blob/main/posts/24-reflect-tracing/examples/trace_emit.cpp) exercises all four forms side-by-side and shows the dump showing each one's resolved name.
 
 ## The engine (Maciek's technique, recapped)
 


### PR DESCRIPTION
## Problem

Post 1 (live) and the GodboltEmbed placeholder both linked to https://github.com/wrocpp/cpp26-playground -- a repo that doesn't exist.

## Fix

Repointed all four references to the actual code repo at https://github.com/wrocpp/cpp26-reflection-examples (created in MR-0; contains the Dockerfile + ./cpp + ./run wrappers + every post's examples/, exactly the workflow post 1's "Try it" section describes).

Touched files:
- src/content/posts/2026-04-26-why-cpp26-reflection-matters.mdx (live)
- src/components/GodboltEmbed.astro (fallbackHref default)
- src/content/posts/2027-01-06-reflect-llmschema.mdx (draft)
- src/content/posts/2027-03-17-reflect-tracing.mdx (draft)

## Test plan

- [ ] Merge.
- [ ] Verify the deploy run is green.
- [ ] Confirm "playground repo" link in the post 1 "Try it" section now resolves to a real repo.