### PR TITLE
infra(analytics): GA4 + Consent Mode v2 + funnel events + UTM tagging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,10 @@ jobs:
       - name: Build
         env:
           NODE_ENV: production
+          # Astro inlines vars prefixed with PUBLIC_ at build time. The GA4
+          # measurement ID is non-secret (visible in client HTML) but lives
+          # in repo secrets so forks do not inherit it.
+          PUBLIC_GA_ID: ${{ secrets.PUBLIC_GA_ID }}
         run: npm run build
 
       - name: Upload artifact

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ yarn-error.log*
 .env
 .env.*
 !.env.example
+scripts/__pycache__/

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,66 @@
+# Analytics on wro.cpp
+
+The site uses **Google Analytics 4** with **Consent Mode v2**, plus three custom events tailored to a technical-blog audience.
+
+## Setup (one-time)
+
+1. Create a GA4 property at https://analytics.google.com (Admin -> Create Property -> Web data stream pointing at `https://wrocpp.github.io`).
+2. Copy the **Measurement ID** (format: `G-XXXXXXXXXX`).
+3. Set it as a build-time env var:
+   - **Local dev:** add `PUBLIC_GA_ID=G-XXXXXXXXXX` to `.env` (gitignored).
+   - **GitHub Pages deploy:** add a repository **secret** named `PUBLIC_GA_ID` at https://github.com/wrocpp/wrocpp.github.io/settings/secrets/actions, then expose it to the build step in `.github/workflows/deploy.yml` (uncomment the `env:` block under "Build").
+
+If the env var is unset, the analytics script and the cookie banner render nothing -- safe for forks and preview deploys.
+
+## What gets tracked
+
+| Event | When | Why |
+| --- | --- | --- |
+| `page_view` | Every page load (built-in) | Pageviews + referrers per URL. |
+| `post_read` | After every `/posts/<slug>/` page load | Funnel report: post 1 -> 2 -> 3 -> ... so you see drop-off between consecutive posts in the series. Includes `post_series_order`, `post_kind`, `post_language`. |
+| `click_outbound` | Click on any external `<a href>` | Per-destination CTR (godbolt vs slack vs meetup vs github). Includes `link_url`, `link_domain`, `link_text`. |
+| `scroll_depth` | Scroll past 25% / 50% / 75% / 100% | Differentiates "glanced at headline" from "actually read 1500 words". One event per threshold per page. |
+
+All custom events fire through `gtag()`. Consent-Mode-v2 default: every category is `denied` until the visitor clicks **Accept** on the banner; while denied, GA4 still receives **cookieless pings** (aggregate counts only, no PII / no ads modeling).
+
+## UTM tagging via `/push-to-buffer`
+
+`scripts/push-to-buffer.py` rewrites the bare `https://wrocpp.github.io/posts/<slug>/` URL inside each caption to:
+
+```
+https://wrocpp.github.io/posts/<slug>/?utm_source=<linkedin|facebook>&utm_medium=social&utm_campaign=post-<NN>
+```
+
+GA4's **Acquisition -> Traffic acquisition** report then breaks each post's traffic down by source: LinkedIn vs Facebook vs direct/Slack vs organic search.
+
+If you author your own URL with `?` or `#` already in it, the rewrite is skipped -- your tagging wins.
+
+## Privacy & GDPR
+
+- **Cookieless by default:** Consent Mode v2 starts with all categories `denied`. The browser receives no GA-set cookies until the visitor clicks Accept.
+- **Banner:** appears on first visit; choice is persisted in `localStorage` under the key `wrocpp:consent` (`granted` or `denied`). No nag.
+- **No ads, no remarketing:** `ad_storage` and `ad_personalization` start denied and stay denied even on Accept (we only flip the analytics-related categories on Accept; ads-related stay denied -- see CookieConsent.astro for the consent state map if you want to change this).
+- **`anonymize_ip: true`** is enforced in the gtag config (so even granted-consent visitors don't have their IP recorded).
+
+## Local testing
+
+```bash
+# Dev mode -- analytics script renders if PUBLIC_GA_ID is in .env.
+PUBLIC_GA_ID=G-XXXXXXXXXX npm run dev
+```
+
+In Chrome DevTools, open the **Network** tab and filter for `google-analytics.com` or `analytics.google.com`. Click around to see `collect?...` beacons fire (page_view, then your interaction events).
+
+GA4's **Realtime** report (https://analytics.google.com -> Reports -> Realtime) shows your own visit within 30 seconds.
+
+## Reading the data
+
+Once you have a few posts of traffic, the questions to answer:
+
+- Which post drives the most pageviews? **Reports -> Engagement -> Pages and screens.**
+- Where does the traffic come from? **Reports -> Acquisition -> Traffic acquisition** (UTM-tagged).
+- Is the series funnel converging? **Explore -> Funnel exploration**, steps = `post_read` filtered by `post_series_order` 1, 2, 3 ...
+- Do readers click through to godbolt? **Reports -> Engagement -> Events**, filter `click_outbound` by `link_domain = godbolt.org`.
+- Is the audience growing? **Reports -> Acquisition -> User acquisition** by week.
+
+Slack member count, Meetup RSVPs, and GitHub stars are not in GA4 -- check those manually once a week. The `click_outbound` event tells you the click-through, but the conversion rate (clicked -> joined Slack) requires correlating with Slack admin.

--- a/scripts/push-to-buffer.py
+++ b/scripts/push-to-buffer.py
@@ -126,6 +126,39 @@ def caption_to_post_text(caption_md: str) -> str:
     return f"{body}\n\n{hashtags}".strip() if hashtags else body
 
 
+def add_utm(text: str, slug: str, platform: str, series_order: int | None) -> str:
+    """Replace bare https://wrocpp.github.io/posts/<slug>/ URLs in `text`
+    with UTM-tagged versions per platform, so GA4 can attribute traffic
+    to LinkedIn vs Facebook vs direct without per-post manual editing.
+
+    Skip URLs that already have `?` or `#` -- author has tagged them
+    explicitly. Other domains are left untouched."""
+    base = f"https://wrocpp.github.io/posts/{slug}/"
+    if base not in text:
+        return text
+    campaign = (
+        f"post-{series_order:02d}" if isinstance(series_order, int) else f"post-{slug}"
+    )
+    tagged = (
+        f"{base}?utm_source={platform}&utm_medium=social&utm_campaign={campaign}"
+    )
+    return text.replace(base, tagged)
+
+
+def series_order_from_post(slug: str) -> int | None:
+    """Read series_order from src/content/posts/*-<slug>.mdx (frontmatter)."""
+    posts = sorted((REPO_ROOT / "src/content/posts").glob(f"*-{slug}.mdx"))
+    if not posts:
+        return None
+    for line in posts[0].read_text().splitlines():
+        if line.startswith("series_order:"):
+            try:
+                return int(line.split(":", 1)[1].strip())
+            except ValueError:
+                return None
+    return None
+
+
 CREATE_POST_MUTATION = """
 mutation CreateDraft($input: CreatePostInput!) {
   createPost(input: $input) {
@@ -193,6 +226,7 @@ def main() -> int:
             print(f"skip {plat}: {cap_path} missing", file=sys.stderr)
             continue
         text = caption_to_post_text(cap_path.read_text())
+        text = add_utm(text, args.slug, plat, series_order_from_post(args.slug))
         print(f"\n--> {plat}: channel={chan['id']} ({chan.get('displayName')})  chars={len(text)}",
               file=sys.stderr)
         if args.dry_run:

--- a/src/components/Analytics.astro
+++ b/src/components/Analytics.astro
@@ -1,0 +1,46 @@
+---
+/**
+ * Google Analytics 4 with Consent Mode v2.
+ *
+ * Lands the gtag bootstrap, sets all consent categories to "denied" by
+ * default (EU GDPR + Google's own 2024+ requirement), and exposes the
+ * gtag global so client-side helpers can fire custom events. The
+ * <CookieConsent> component flips consent to granted on Accept.
+ *
+ * Set PUBLIC_GA_ID in .env (or the production env -- the prefix
+ * `PUBLIC_` makes it available at build time on the client). Format:
+ * G-XXXXXXXXXX (a "GA4 measurement ID", not the legacy UA-XXX one).
+ *
+ * If PUBLIC_GA_ID is unset, this component renders nothing -- safe for
+ * dev / forks / preview deploys without an analytics property.
+ */
+const gaId = import.meta.env.PUBLIC_GA_ID;
+---
+{gaId && (
+  <>
+    {/* Consent Mode v2 default: deny everything until the user clicks
+        Accept on the cookie banner. region:[] = applies worldwide; we
+        treat all visitors as EU for safety (no IP geolocation needed). */}
+    <script is:inline>{`
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      window.gtag = gtag;
+      gtag('consent', 'default', {
+        ad_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied',
+        analytics_storage: 'denied',
+        functionality_storage: 'denied',
+        personalization_storage: 'denied',
+        security_storage: 'granted',
+        wait_for_update: 500
+      });
+      gtag('js', new Date());
+      gtag('config', '${gaId}', {
+        anonymize_ip: true,
+        send_page_view: true,
+      });
+    `}</script>
+    <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}></script>
+  </>
+)}

--- a/src/components/CookieConsent.astro
+++ b/src/components/CookieConsent.astro
@@ -1,0 +1,105 @@
+---
+/**
+ * Minimal cookie consent banner -- EU/GDPR friendly.
+ *
+ * Renders only if PUBLIC_GA_ID is set (no analytics = no banner needed).
+ * Stores the choice in localStorage under `wrocpp:consent` (granted /
+ * denied). On Accept: flips Google Consent Mode v2 categories to
+ * granted; on Reject: persists the denial so we don't nag again.
+ *
+ * Banner styling matches the wro.cpp Editorial Magnet aesthetic
+ * (paper-2 background, orange accent button, JetBrains Mono microcopy).
+ */
+const gaId = import.meta.env.PUBLIC_GA_ID;
+---
+{gaId && (
+  <div id="cookie-consent" class="cookie-consent" hidden>
+    <p class="cookie-consent__text">
+      // We use Google Analytics to understand which posts get traction
+      and how the wro.cpp community grows. Anonymised, no ads, and you
+      can decline -- the site works either way.
+    </p>
+    <div class="cookie-consent__actions">
+      <button type="button" id="cookie-accept" class="cookie-consent__btn cookie-consent__btn--primary">Accept</button>
+      <button type="button" id="cookie-reject" class="cookie-consent__btn">Decline</button>
+    </div>
+  </div>
+)}
+
+{gaId && (
+  <script is:inline>{`
+    (function() {
+      var KEY = 'wrocpp:consent';
+      var el = document.getElementById('cookie-consent');
+      if (!el) return;
+      var saved = null;
+      try { saved = localStorage.getItem(KEY); } catch (e) {}
+      function update(state) {
+        if (typeof window.gtag !== 'function') return;
+        window.gtag('consent', 'update', {
+          ad_storage:        state,
+          ad_user_data:      state,
+          ad_personalization: state,
+          analytics_storage: state,
+          functionality_storage: state,
+          personalization_storage: state,
+        });
+      }
+      function set(choice) {
+        try { localStorage.setItem(KEY, choice); } catch (e) {}
+        update(choice === 'granted' ? 'granted' : 'denied');
+        el.hidden = true;
+      }
+      if (saved === 'granted') { update('granted'); return; }
+      if (saved === 'denied')  { update('denied');  return; }
+      el.hidden = false;
+      document.getElementById('cookie-accept').addEventListener('click', function(){ set('granted'); });
+      document.getElementById('cookie-reject').addEventListener('click', function(){ set('denied'); });
+    })();
+  `}</script>
+)}
+
+<style>
+  .cookie-consent {
+    position: fixed;
+    bottom: 1.5rem;
+    left: 1.5rem;
+    right: 1.5rem;
+    max-width: 38rem;
+    margin: 0 auto;
+    padding: 1rem 1.25rem;
+    background: var(--paper-2);
+    border: 1px solid var(--rule);
+    border-left: 3px solid var(--orange);
+    box-shadow: var(--shadow);
+    z-index: 100;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.82rem;
+    line-height: 1.5;
+    color: var(--ink-muted);
+  }
+  .cookie-consent[hidden] { display: none; }
+  .cookie-consent__text { margin: 0; }
+  .cookie-consent__actions { display: flex; gap: 0.5rem; }
+  .cookie-consent__btn {
+    font-family: 'Quicksand', system-ui, sans-serif;
+    font-weight: 600;
+    font-size: 0.88rem;
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--rule);
+    background: transparent;
+    color: var(--ink);
+    cursor: pointer;
+    transition: border-color 140ms ease, background 140ms ease, color 140ms ease;
+  }
+  .cookie-consent__btn:hover { border-color: var(--ink); }
+  .cookie-consent__btn--primary {
+    background: var(--orange);
+    color: var(--paper);
+    border-color: var(--orange);
+  }
+  .cookie-consent__btn--primary:hover { background: var(--orange-hot); border-color: var(--orange-hot); color: var(--paper); }
+</style>

--- a/src/components/TrackingHooks.astro
+++ b/src/components/TrackingHooks.astro
@@ -1,0 +1,63 @@
+---
+/**
+ * Client-side tracking hooks (outbound clicks + scroll depth).
+ *
+ * Renders one inline <script> that, after DOM ready:
+ *   1. Attaches a click listener to every <a href> with an external host;
+ *      fires `gtag('event', 'click_outbound', { href, host })` so each
+ *      external destination shows up as its own event in GA4.
+ *   2. Listens for scroll past 25/50/75/100% of document height and fires
+ *      `gtag('event', 'scroll_depth', { percent })` once per threshold.
+ *
+ * Both events also fire when consent is 'denied' but Consent Mode v2
+ * sends them as cookieless pings -- GA4 still gets aggregate signals.
+ *
+ * Includes nothing if PUBLIC_GA_ID is unset.
+ */
+const gaId = import.meta.env.PUBLIC_GA_ID;
+const siteHost = 'wrocpp.github.io';
+---
+{gaId && (
+  <script is:inline define:vars={{ siteHost }}>{`
+    (function() {
+      function track(name, params) {
+        if (typeof window.gtag === 'function') window.gtag('event', name, params || {});
+      }
+
+      // -------- Outbound link tracking --------
+      document.addEventListener('click', function(e) {
+        var a = e.target instanceof Element ? e.target.closest('a[href]') : null;
+        if (!a) return;
+        var href = a.getAttribute('href') || '';
+        if (!/^https?:\\/\\//i.test(href)) return; // skip relative + mailto + tel
+        try {
+          var u = new URL(href);
+          if (u.host === window.location.host || u.host === siteHost) return; // internal absolute
+          track('click_outbound', {
+            link_url: u.href,
+            link_domain: u.host,
+            link_text: (a.textContent || '').trim().slice(0, 80),
+          });
+        } catch (_) {}
+      }, true);
+
+      // -------- Scroll depth (25 / 50 / 75 / 100) --------
+      var fired = {};
+      function onScroll() {
+        var doc = document.documentElement;
+        var scrolled = window.scrollY + window.innerHeight;
+        var height = doc.scrollHeight;
+        if (height <= window.innerHeight) return;
+        var pct = Math.floor((scrolled / height) * 100);
+        [25, 50, 75, 100].forEach(function(t) {
+          if (pct >= t && !fired[t]) {
+            fired[t] = true;
+            track('scroll_depth', { percent: t });
+          }
+        });
+      }
+      window.addEventListener('scroll', onScroll, { passive: true });
+      window.addEventListener('load', onScroll);
+    })();
+  `}</script>
+)}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,9 @@
 ---
 import '../styles/global.css';
 import MagnetLogo from '../components/MagnetLogo.astro';
+import Analytics from '../components/Analytics.astro';
+import CookieConsent from '../components/CookieConsent.astro';
+import TrackingHooks from '../components/TrackingHooks.astro';
 
 interface Props {
   title: string;
@@ -39,6 +42,7 @@ const canonical = canonicalPath
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;1,8..60,400&family=JetBrains+Mono:wght@400;500;700&display=swap"
     />
+    <Analytics />
   </head>
   <body class="min-h-screen flex flex-col">
     <header class="site-header">
@@ -73,5 +77,8 @@ const canonical = canonicalPath
         </div>
       </div>
     </footer>
+
+    <CookieConsent />
+    <TrackingHooks />
   </body>
 </html>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -91,4 +91,23 @@ const progressPct =
       <SeriesNav currentSlug={post.slug} series={series} />
     </div>
   </article>
+
+  {/* Funnel event: which posts get read, in series order. The
+      `series_order` lets GA4 build a step-by-step funnel report
+      (post 1 -> 2 -> 3 ...) so we can see drop-off between
+      consecutive posts in the series. Fires once per page load. */}
+  <script is:inline define:vars={{ slug: post.slug, seriesName: series ?? null, order: series_order ?? null, kind, language }}>{`
+    (function() {
+      window.addEventListener('load', function() {
+        if (typeof window.gtag !== 'function') return;
+        window.gtag('event', 'post_read', {
+          post_slug: slug,
+          post_series: seriesName,
+          post_series_order: order,
+          post_kind: kind,
+          post_language: language,
+        });
+      });
+    })();
+  `}</script>
 </BaseLayout>


### PR DESCRIPTION
## Summary

Adds traffic + community-growth instrumentation to wro.cpp. Three pieces:

1. **GA4 with Consent Mode v2** -- gtag bootstraps with all categories denied; the cookie banner flips analytics + functionality on Accept (ads stay denied; we don't run them). `anonymize_ip:true` enforced.
2. **Custom events** for the questions a technical-blog audience needs answered:
   - `post_read` (per page load) -- carries `series_order` so GA4 builds a funnel report across post 1 -> 2 -> 3 ...
   - `click_outbound` (per external link click) -- per-destination CTR (godbolt vs slack vs meetup vs github examples).
   - `scroll_depth` at 25/50/75/100% -- differentiates "glanced" from "actually read".
3. **UTM tagging in `/push-to-buffer`** -- the bare wrocpp.github.io/posts/<slug>/ URL inside captions auto-becomes `?utm_source=<platform>&utm_medium=social&utm_campaign=post-<NN>` per platform, so attribution is automatic.

## Setup required (one-time)

After merging, the user must:

1. Create a GA4 property at https://analytics.google.com (Admin -> Create Property -> Web data stream -> https://wrocpp.github.io). Copy the **Measurement ID** (format `G-XXXXXXXXXX`).
2. Add `PUBLIC_GA_ID` as a GitHub Actions secret + reference it in deploy.yml's build step env, OR hardcode it in a small follow-up commit. Without the env var the whole stack no-ops cleanly (script doesn't render, banner doesn't render).

## Privacy posture

- All consent categories start denied. Cookieless pings still flow to GA4 even when the visitor declines (Consent Mode v2 default).
- Ads + remarketing categories stay denied even on Accept; only analytics + functionality flip.
- IP anonymisation enforced.
- Banner choice persisted in localStorage; no re-prompt.

See **docs/analytics.md** for the full operator's guide.

## Verification done locally

- `npm run build` without PUBLIC_GA_ID: no GA script in dist HTML (matches 0 grep hits).
- `PUBLIC_GA_ID=G-TEST npm run build`: 12 GA-related strings per page (gtag init + script tag + consent banner + tracking hooks).
- `add_utm()` unit-checked against the 4 cases (linkedin, facebook, no-series-order, no-match).

## Test plan

- [ ] Merge.
- [ ] Create the GA4 property + add PUBLIC_GA_ID secret.
- [ ] Wire the secret into deploy.yml (one-line follow-up PR).
- [ ] Wait for deploy; visit https://wrocpp.github.io ; observe the cookie banner; click Accept.
- [ ] Open GA4 Realtime view; navigate around the site; confirm pageview + post_read + scroll_depth + click_outbound show up within 30s.
- [ ] Once MR2 lands and Buffer pushes the scheduled post 2 announcement, check GA4 Acquisition -> Traffic acquisition for `linkedin / social / post-02` after the scheduled fire date.