### PR TITLE
fix(analytics): inline-script template-literal wrapper broke GA + banner

### DIFF
--- a/src/components/Analytics.astro
+++ b/src/components/Analytics.astro
@@ -2,9 +2,9 @@
 /**
  * Google Analytics 4 with Consent Mode v2.
  *
- * Lands the gtag bootstrap, sets all consent categories to "denied" by
- * default (EU GDPR + Google's own 2024+ requirement), and exposes the
- * gtag global so client-side helpers can fire custom events. The
+ * Bootstraps gtag, sets all consent categories to "denied" by default
+ * (EU GDPR + Google's own 2024+ requirement), and exposes the gtag
+ * global so client-side helpers can fire custom events. The
  * <CookieConsent> component flips consent to granted on Accept.
  *
  * Set PUBLIC_GA_ID in .env (or the production env -- the prefix
@@ -18,10 +18,11 @@ const gaId = import.meta.env.PUBLIC_GA_ID;
 ---
 {gaId && (
   <>
-    {/* Consent Mode v2 default: deny everything until the user clicks
-        Accept on the cookie banner. region:[] = applies worldwide; we
-        treat all visitors as EU for safety (no IP geolocation needed). */}
-    <script is:inline>{`
+    {/* Inline script: server-side gaId injected via define:vars so
+        Astro doesn't try to bundle / hash this file. is:inline keeps
+        the body verbatim in the head; define:vars makes `gaId` a
+        plain `const` at the top of the script. */}
+    <script is:inline define:vars={{ gaId }}>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       window.gtag = gtag;
@@ -36,11 +37,14 @@ const gaId = import.meta.env.PUBLIC_GA_ID;
         wait_for_update: 500
       });
       gtag('js', new Date());
-      gtag('config', '${gaId}', {
+      gtag('config', gaId, {
         anonymize_ip: true,
         send_page_view: true,
       });
-    `}</script>
-    <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}></script>
+      var s = document.createElement('script');
+      s.async = true;
+      s.src = 'https://www.googletagmanager.com/gtag/js?id=' + gaId;
+      document.head.appendChild(s);
+    </script>
   </>
 )}

--- a/src/components/CookieConsent.astro
+++ b/src/components/CookieConsent.astro
@@ -27,7 +27,7 @@ const gaId = import.meta.env.PUBLIC_GA_ID;
 )}
 
 {gaId && (
-  <script is:inline>{`
+  <script is:inline>
     (function() {
       var KEY = 'wrocpp:consent';
       var el = document.getElementById('cookie-consent');
@@ -56,7 +56,7 @@ const gaId = import.meta.env.PUBLIC_GA_ID;
       document.getElementById('cookie-accept').addEventListener('click', function(){ set('granted'); });
       document.getElementById('cookie-reject').addEventListener('click', function(){ set('denied'); });
     })();
-  `}</script>
+  </script>
 )}
 
 <style>

--- a/src/components/TrackingHooks.astro
+++ b/src/components/TrackingHooks.astro
@@ -18,7 +18,7 @@ const gaId = import.meta.env.PUBLIC_GA_ID;
 const siteHost = 'wrocpp.github.io';
 ---
 {gaId && (
-  <script is:inline define:vars={{ siteHost }}>{`
+  <script is:inline define:vars={{ siteHost }}>
     (function() {
       function track(name, params) {
         if (typeof window.gtag === 'function') window.gtag('event', name, params || {});
@@ -29,7 +29,7 @@ const siteHost = 'wrocpp.github.io';
         var a = e.target instanceof Element ? e.target.closest('a[href]') : null;
         if (!a) return;
         var href = a.getAttribute('href') || '';
-        if (!/^https?:\\/\\//i.test(href)) return; // skip relative + mailto + tel
+        if (!/^https?:\/\//i.test(href)) return; // skip relative + mailto + tel
         try {
           var u = new URL(href);
           if (u.host === window.location.host || u.host === siteHost) return; // internal absolute
@@ -59,5 +59,5 @@ const siteHost = 'wrocpp.github.io';
       window.addEventListener('scroll', onScroll, { passive: true });
       window.addEventListener('load', onScroll);
     })();
-  `}</script>
+  </script>
 )}

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -96,7 +96,7 @@ const progressPct =
       `series_order` lets GA4 build a step-by-step funnel report
       (post 1 -> 2 -> 3 ...) so we can see drop-off between
       consecutive posts in the series. Fires once per page load. */}
-  <script is:inline define:vars={{ slug: post.slug, seriesName: series ?? null, order: series_order ?? null, kind, language }}>{`
+  <script is:inline define:vars={{ slug: post.slug, seriesName: series ?? null, order: series_order ?? null, kind, language }}>
     (function() {
       window.addEventListener('load', function() {
         if (typeof window.gtag !== 'function') return;
@@ -109,5 +109,5 @@ const progressPct =
         });
       });
     })();
-  `}</script>
+  </script>
 </BaseLayout>


### PR DESCRIPTION
## Problem

Live site shows 0 users in GA4 Realtime; cookie banner doesn't appear. Investigation showed the inline scripts in Analytics / CookieConsent / TrackingHooks / PostLayout were rendered to HTML as:

\`\`\`html
<script>{\`
  ...JS body...
\`}</script>
\`\`\`

The literal \`{\` and backticks are NOT valid JavaScript; the browser parses them as a syntax error and skips the script. As a result:
- gtag never initialises -> no GA pings
- cookie-consent script never runs -> banner stays \`hidden\`
- outbound + scroll + post_read events never fire

## Root cause

In Astro, \`<script is:inline>{\`...\`}</script>\` looks like the body is interpolated, but Astro treats the JSX expression \`{...}\` as a string-typed child of \`<script>\`, then emplaces it verbatim. The JSX evaluator doesn't unwrap the template literal. The pattern works for some attributes but not for is:inline script bodies.

## Fix

Drop the \`{\`...\`}\` wrapper everywhere; put raw JS directly inside \`<script is:inline>\`. For server-side values that need injecting (e.g. \`gaId\`, \`siteHost\`, the post slug for the funnel), use \`define:vars={{ ... }}\` which Astro injects as \`const <name> = <value>;\` at the top of the script -- the proper pattern.

Verified rendered HTML now has executable JS like:
\`\`\`
<script>(function(){const gaId = "G-XXXXXXXXXX";
  window.dataLayer = ...;
  gtag('config', gaId, { ... });
})();</script>
\`\`\`

No literal \`{\` backtick anywhere.

## Test plan

- [ ] Merge.
- [ ] Wait for deploy.
- [ ] \`curl -s https://wrocpp.github.io/ | grep -c '<script>{\`'\` returns 0.
- [ ] Open https://wrocpp.github.io in incognito; cookie banner shows up at the bottom-left.
- [ ] Click Accept; GA4 Realtime view shows your visit within 30s.
- [ ] Click an outbound link (e.g. github footer); \`click_outbound\` event count goes up in Realtime.