### PR TITLE
feat: per-post GitHub Discussion threads (auto-create + retrofit post 1)

### DIFF
--- a/.claude/skills/publish-post/SKILL.md
+++ b/.claude/skills/publish-post/SKILL.md
@@ -86,6 +86,22 @@ Use `AskUserQuestion` to confirm a subset of edits if the proposed list is large
 
 In the new post's mdx, change `draft: true` -> `draft: false`. Leave `pubDate` alone (the daily cron build at 07:00 UTC publishes on its own). Pass `--publish-now` to the skill to also bump pubDate to today and rename the file accordingly.
 
+### 7b. Create the post's GitHub Discussion thread
+
+Spawn a discussion thread for the new post so readers have a per-post place to ask questions. Idempotent (skipped if frontmatter already has `discussion:`).
+
+```
+python3 scripts/create-discussion.py --slug <slug>
+```
+
+The script:
+- Reads the post's frontmatter.
+- Looks up the godbolt id (if any) for a "try the code" link in the discussion body.
+- Calls the `createDiscussion` GraphQL mutation in the `General` category.
+- **Patches the mdx**: adds `discussion: <url>` to the frontmatter and rewrites any generic `https://github.com/wrocpp/wrocpp.github.io/discussions` link in the body to point at the specific thread.
+
+The discussion link surfaces in `PostLayout`'s article meta as `· discuss` and in the post's own CTA paragraph.
+
 ### 8. Build sanity check
 
 ```

--- a/scripts/create-discussion.py
+++ b/scripts/create-discussion.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""
+Create one GitHub Discussion thread per wro.cpp post.
+
+Used by /publish-post (and runnable standalone) to spawn a discussion
+when a post ships, then print its URL so the post mdx can link to the
+specific thread instead of the generic /discussions list.
+
+Reads the post's frontmatter (title, slug, series, series_order) from
+src/content/posts/*-<slug>.mdx, then calls the GitHub GraphQL
+createDiscussion mutation. Authentication uses `gh auth token`
+(re-uses the user's existing gh login -- no separate token needed).
+
+Defaults to the "General" category. Override with --category if you
+later create a custom "Posts" category in repo settings.
+
+Usage:
+    scripts/create-discussion.py --slug first-reflection
+    scripts/create-discussion.py --slug first-reflection --category General
+    scripts/create-discussion.py --slug first-reflection --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GH_OWNER = "wrocpp"
+GH_REPO = "wrocpp.github.io"
+GH_GRAPHQL = "https://api.github.com/graphql"
+SITE_BASE = "https://wrocpp.github.io"
+
+
+def gh_token() -> str:
+    """Use the gh CLI's existing auth -- no separate PAT needed."""
+    try:
+        out = subprocess.check_output(["gh", "auth", "token"], text=True).strip()
+    except (FileNotFoundError, subprocess.CalledProcessError) as e:
+        sys.exit(f"error: cannot get gh auth token: {e}. Run `gh auth login` first.")
+    if not out:
+        sys.exit("error: empty gh auth token")
+    return out
+
+
+def gql(token: str, query: str, variables: dict | None = None) -> dict:
+    body = json.dumps({"query": query, "variables": variables or {}}).encode()
+    req = urllib.request.Request(
+        GH_GRAPHQL,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "wrocpp-create-discussion/1.0",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            out = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        sys.exit(f"github http {e.code}: {e.read().decode(errors='replace')[:500]}")
+    if out.get("errors"):
+        sys.exit(f"github graphql error: {json.dumps(out['errors'], indent=2)}")
+    return out["data"]
+
+
+def read_frontmatter(slug: str) -> dict:
+    """Parse the YAML-ish frontmatter of src/content/posts/*-<slug>.mdx
+    enough to grab title / pubDate / series / series_order / godbolt_id."""
+    posts = sorted((REPO_ROOT / "src/content/posts").glob(f"*-{slug}.mdx"))
+    if not posts:
+        sys.exit(f"error: no mdx for slug {slug!r}")
+    text = posts[0].read_text()
+    if not text.startswith("---"):
+        sys.exit(f"error: {posts[0]} has no frontmatter")
+    end = text.find("\n---", 3)
+    if end < 0:
+        sys.exit(f"error: unterminated frontmatter in {posts[0]}")
+    fm: dict = {}
+    for line in text[3:end].splitlines():
+        m = re.match(r'^(\w+):\s*"?([^"\n]*?)"?\s*$', line)
+        if m:
+            fm[m.group(1)] = m.group(2)
+    if "title" not in fm:
+        sys.exit(f"error: {posts[0]} missing title in frontmatter")
+    return fm
+
+
+def godbolt_id_for(slug: str) -> str | None:
+    """Pick the first godbolt entry for the post, if any. Used to surface
+    a 'try the code' link inside the discussion body."""
+    yml = REPO_ROOT / "src/data/godbolt-permalinks.yml"
+    if not yml.exists():
+        return None
+    in_post = False
+    indent = None
+    for line in yml.read_text().splitlines():
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if not line.startswith(" "):
+            in_post = (line.rstrip(":") == slug)
+            indent = None
+            continue
+        if not in_post:
+            continue
+        m = re.match(r'^(\s+)id:\s*(.+)$', line)
+        if m:
+            return m.group(2).strip()
+    return None
+
+
+def discussion_body(fm: dict, godbolt: str | None) -> str:
+    title = fm["title"]
+    slug = fm["slug"]
+    series = fm.get("series")
+    order = fm.get("series_order")
+    post_url = f"{SITE_BASE}/posts/{slug}/"
+    series_str = f"part {order}" if order else ""
+    if series and series_str:
+        series_line = f"\n**{series_str} of the [{series}]({SITE_BASE}/series/{series}/) series.**\n"
+    else:
+        series_line = ""
+    godbolt_line = (
+        f"\n- The Compiler Explorer playground: <https://godbolt.org/z/{godbolt}>\n"
+        if godbolt else ""
+    )
+    return f"""# {title}
+{series_line}
+This is the discussion thread for **[{title}]({post_url})**.
+
+**Use this thread for:**
+- Questions about the code in the post
+- Corrections or suggested improvements
+- Your own variations / war stories
+
+**Quick links:**
+- The post: <{post_url}>{godbolt_line}- The wro.cpp series: <{SITE_BASE}/series/cpp26-reflection/>
+- Slack (#wro.cpp): <https://wrocpp.slack.com>
+
+If you spot a bug in the code or the prose, a comment here or a PR against [wrocpp.github.io](https://github.com/{GH_OWNER}/{GH_REPO}) both work.
+"""
+
+
+CATS_QUERY = """
+query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    id
+    discussionCategories(first: 25) { nodes { id name slug isAnswerable } }
+  }
+}
+"""
+
+CREATE_MUTATION = """
+mutation($repoId: ID!, $catId: ID!, $title: String!, $body: String!) {
+  createDiscussion(input: {repositoryId: $repoId, categoryId: $catId, title: $title, body: $body}) {
+    discussion { id number url title }
+  }
+}
+"""
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--slug", required=True, help="post slug, e.g. first-reflection")
+    p.add_argument("--category", default="General",
+                   help="discussion category name (default: General)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="resolve ids + show payload, do not create")
+    args = p.parse_args()
+
+    fm = read_frontmatter(args.slug)
+    godbolt = godbolt_id_for(args.slug)
+    title = fm["title"]
+    body = discussion_body(fm, godbolt)
+
+    print(f"--> post: {title}", file=sys.stderr)
+    print(f"    slug: {args.slug}", file=sys.stderr)
+    if godbolt:
+        print(f"    godbolt: {godbolt}", file=sys.stderr)
+
+    token = gh_token()
+
+    cats = gql(token, CATS_QUERY, {"owner": GH_OWNER, "name": GH_REPO})["repository"]
+    repo_id = cats["id"]
+    cat = next(
+        (c for c in cats["discussionCategories"]["nodes"]
+         if c["name"].lower() == args.category.lower()),
+        None,
+    )
+    if not cat:
+        names = ", ".join(c["name"] for c in cats["discussionCategories"]["nodes"])
+        sys.exit(f"error: category {args.category!r} not found. Available: {names}")
+    print(f"    category: {cat['name']} ({cat['id']})", file=sys.stderr)
+
+    if args.dry_run:
+        print("\n--- title ---")
+        print(title)
+        print("\n--- body ---")
+        print(body)
+        print("\n(dry-run; no discussion created)")
+        return 0
+
+    # Skip if the post already has a discussion URL in frontmatter --
+    # avoids duplicate threads if the skill is re-run.
+    if fm.get("discussion"):
+        print(f"\nskip: post already has discussion: {fm['discussion']}", file=sys.stderr)
+        print(fm["discussion"])
+        return 0
+
+    out = gql(token, CREATE_MUTATION, {
+        "repoId": repo_id,
+        "catId": cat["id"],
+        "title": title,
+        "body": body,
+    })["createDiscussion"]["discussion"]
+    discussion_url = out["url"]
+    print(f"\nok   created discussion #{out['number']}", file=sys.stderr)
+
+    # Patch the mdx: add `discussion: <url>` to the frontmatter (after the
+    # `summary:` line, conventionally) AND rewrite the generic
+    # /discussions link in the body to the specific thread.
+    posts = sorted((REPO_ROOT / "src/content/posts").glob(f"*-{args.slug}.mdx"))
+    mdx_path = posts[0]
+    text = mdx_path.read_text()
+    end = text.find("\n---", 3)
+    fm_block, body_block = text[3:end], text[end + 4:]
+    if "discussion:" not in fm_block:
+        # Insert before the closing of frontmatter, after the last field.
+        fm_block = fm_block.rstrip() + f'\ndiscussion: {discussion_url}\n'
+    body_block = body_block.replace(
+        f"https://github.com/{GH_OWNER}/{GH_REPO}/discussions",
+        discussion_url,
+    )
+    mdx_path.write_text("---" + fm_block + "---" + body_block)
+    print(f"ok   patched {mdx_path.relative_to(REPO_ROOT)}", file=sys.stderr)
+    print(discussion_url)  # stdout: just the URL, easy to capture in shell
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/content/posts/2026-04-26-why-cpp26-reflection-matters.mdx
+++ b/src/content/posts/2026-04-26-why-cpp26-reflection-matters.mdx
@@ -11,6 +11,7 @@ audience: polyglot
 tags: [reflection, cpp26, motivation, p2996]
 summary: "Part 1 of the C++26 reflection series. A 40-line JSON serializer nobody could write in C++ before 2026 — plus the strategic story of why static reflection changes the ecosystem."
 draft: false
+discussion: https://github.com/wrocpp/wrocpp.github.io/discussions/11
 ---
 
 import GodboltEmbed from '../../components/GodboltEmbed.astro';
@@ -228,4 +229,4 @@ This is part 1 of a multi-post series. The next instalments take this teaser apa
 
 The full plan, with publication dates, lives on the [`cpp26-reflection` series page](/series/cpp26-reflection/). Each post lands as it ships.
 
-Questions, corrections, or your own reflection war stories: drop them on [Slack](https://wrocpp.slack.com) or in the [GitHub Discussions](https://github.com/wrocpp/wrocpp.github.io/discussions) for this post.
+Questions, corrections, or your own reflection war stories: drop them on [Slack](https://wrocpp.slack.com) or in the [GitHub Discussion](https://github.com/wrocpp/wrocpp.github.io/discussions/11) for this post.

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -8,7 +8,7 @@ interface Props {
   post: CollectionEntry<'posts'>;
 }
 const { post } = Astro.props;
-const { title, summary, pubDate, updatedDate, language, tags, series, series_order, audience, kind, draft } =
+const { title, summary, pubDate, updatedDate, language, tags, series, series_order, audience, kind, draft, discussion } =
   post.data;
 const date = pubDate.toISOString().slice(0, 10);
 
@@ -76,6 +76,7 @@ const progressPct =
           {updatedDate && <span>· upd {updatedDate.toISOString().slice(0, 10)}</span>}
           <span>· {language === 'pl' ? 'polish' : 'english'}</span>
           <span>· audience: {audience}</span>
+          {discussion && <span>· <a href={discussion} rel="external">discuss</a></span>}
         </div>
         {tags.length > 0 && (
           <ul class="article-head__tags" role="list">


### PR DESCRIPTION
## Summary

Adds one Discussion thread per published post, automatically created and linked back from the post body + meta.

Three commits:

1. **scripts/create-discussion.py** -- standalone CLI. Reads post frontmatter, calls \`createDiscussion\` GraphQL with the gh CLI's existing auth, patches the mdx with the resulting URL. Idempotent (skips if frontmatter already has \`discussion:\`).
2. **PostLayout** surfaces the discussion link as \`· discuss\` in article meta (uses the existing schema field \`discussion: z.string().url().optional()\` which was declared but unrendered). Plus /publish-post SKILL.md step 7b documents the integration.
3. **post-1 retrofit** -- discussion #11 was created out-of-band as the dog-food test; this commit wires the URL into post 1's frontmatter and rewrites the generic \`/discussions\` body link to the specific thread.

## Verification

- \`python3 scripts/create-discussion.py --slug why-cpp26-reflection-matters --dry-run\` -- prints the resolved title + body + category, no creation.
- Real run on post 1 created https://github.com/wrocpp/wrocpp.github.io/discussions/11.
- \`npm run build\` clean; rendered HTML for post 1 has 2 hits for \`discussions/11\` (one in meta, one in body CTA).

## Test plan

- [ ] Merge.
- [ ] Wait for deploy.
- [ ] Visit https://wrocpp.github.io/posts/why-cpp26-reflection-matters/ -- confirm \`· discuss\` link in the meta and the specific link in the bottom CTA both go to discussion #11.
- [ ] Future MR2..25: /publish-post auto-runs step 7b and writes the new thread URL into each post's mdx in the same PR.

## Out of scope (deferred)

- Custom "Posts" discussion category. Default is "General"; create a "Posts" category in repo settings later if you want stricter organization, then pass \`--category Posts\` from the skill.
- Auto-pinning the latest discussion. Manual via the Discussions UI.