### PR TITLE
chore: cascade publish cadence to every 2 days (series ends 2026-06-14)

### DIFF
--- a/scripts/push-to-buffer.py
+++ b/scripts/push-to-buffer.py
@@ -67,7 +67,18 @@ def gql(token: str, query: str, variables: dict | None = None) -> dict:
             out = json.loads(resp.read().decode())
     except urllib.error.HTTPError as e:
         body = e.read().decode(errors="replace")
-        sys.exit(f"buffer http {e.code}: {body[:500]}")
+        try:
+            err = json.loads(body)
+            msgs = []
+            for x in err.get("errors", []):
+                # Buffer puts the variable-coercion failure reason at the END
+                # of the message (after a long inline copy of the value).
+                # Show the last 200 chars so the actual reason is visible.
+                m = x.get("message", "")
+                msgs.append(m if len(m) < 400 else m[:200] + " ... " + m[-300:])
+            sys.exit(f"buffer http {e.code}:\n  - " + "\n  - ".join(msgs))
+        except (ValueError, KeyError):
+            sys.exit(f"buffer http {e.code}: {body[:1000]}")
     if out.get("errors"):
         sys.exit(f"buffer graphql error: {json.dumps(out['errors'], indent=2)}")
     return out["data"]
@@ -225,6 +236,7 @@ def create_post(
     *,
     save_to_draft: bool,
     due_at: str | None,
+    service: str,
 ) -> dict:
     """Create a Buffer post. Two modes:
       - drafts (save_to_draft=True): lands in Buffer's Drafts tab, requires
@@ -237,14 +249,29 @@ def create_post(
         "channelId": channel_id,
         "assets": {"images": [{"url": image_url}]},
     }
+    # Per-platform metadata: Facebook requires PostTypeFacebook (post / story
+    # / reel). LinkedIn / Twitter / Instagram have their own optional inputs;
+    # we omit them here since defaults work for our use case (single-image
+    # feed posts on a company page / personal profile).
+    svc = (service or "").lower()
+    if "facebook" in svc:
+        inp["metadata"] = {"facebook": {"type": "post"}}
+
+    # Buffer GraphQL split:
+    #   schedulingType (enum: notification | automatic) -- "automatic" means
+    #     Buffer publishes to the platform itself, not via mobile push. This
+    #     is what we want for an unattended workflow.
+    #   mode (typed ShareMode!: addToQueue | shareNow | shareNext |
+    #     customScheduled | recommendedTime) -- governs WHEN. customScheduled
+    #     requires dueAt.
+    inp["schedulingType"] = "automatic"
     if save_to_draft:
-        inp["schedulingType"] = "automatic"
         inp["mode"] = "addToQueue"
         inp["saveToDraft"] = True
     else:
         if not due_at:
             sys.exit("error: scheduled mode requires --at or a parseable pubDate")
-        inp["schedulingType"] = "customScheduled"
+        inp["mode"] = "customScheduled"
         inp["dueAt"] = due_at
     return gql(token, CREATE_POST_MUTATION, {"input": inp})
 
@@ -330,6 +357,7 @@ def main() -> int:
         result = create_post(
             token, chan["id"], text, args.image_url,
             save_to_draft=args.draft, due_at=due_at,
+            service=chan.get("service") or plat,
         )["createPost"]
         if result.get("__typename") == "PostActionSuccess":
             post = result["post"]

--- a/src/content/posts/2026-04-29-first-reflection.mdx
+++ b/src/content/posts/2026-04-29-first-reflection.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Your first ^^: reflecting types and walking members"
 slug: "first-reflection"
-pubDate: 2026-05-13
+pubDate: 2026-04-29
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-05-01-splicing.mdx
+++ b/src/content/posts/2026-05-01-splicing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Splicing: [: r :] and putting reflections back into code"
 slug: "splicing"
-pubDate: 2026-05-27
+pubDate: 2026-05-01
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-05-03-template-for-expansion-statements.mdx
+++ b/src/content/posts/2026-05-03-template-for-expansion-statements.mdx
@@ -1,7 +1,7 @@
 ---
 title: "template for: iterating reflections at compile time"
 slug: "template-for-expansion-statements"
-pubDate: 2026-06-10
+pubDate: 2026-05-03
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-05-05-enum-to-string.mdx
+++ b/src/content/posts/2026-05-05-enum-to-string.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Goodbye magic_enum: enum reflection done right"
 slug: "enum-to-string"
-pubDate: 2026-06-24
+pubDate: 2026-05-05
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-05-07-auto-formatter.mdx
+++ b/src/content/posts/2026-05-07-auto-formatter.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Auto-generating std::formatter<T> for any aggregate"
 slug: "auto-formatter"
-pubDate: 2026-07-08
+pubDate: 2026-05-07
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-05-09-derive-eq-hash.mdx
+++ b/src/content/posts/2026-05-09-derive-eq-hash.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Deriving equality, hashing, and ordering from structure"
 slug: "derive-eq-hash"
-pubDate: 2026-07-22
+pubDate: 2026-05-09
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-05-11-json-naive.mdx
+++ b/src/content/posts/2026-05-11-json-naive.mdx
@@ -1,7 +1,7 @@
 ---
 title: "A 40-line JSON serializer with reflection"
 slug: "json-naive"
-pubDate: 2026-08-05
+pubDate: 2026-05-11
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-05-13-annotations.mdx
+++ b/src/content/posts/2026-05-13-annotations.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Annotations: tag-driven serialization comes to C++"
 slug: "annotations"
-pubDate: 2026-08-19
+pubDate: 2026-05-13
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-05-15-json-deserialize.mdx
+++ b/src/content/posts/2026-05-15-json-deserialize.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Deserialization and std::expected: completing the round-trip"
 slug: "json-deserialize"
-pubDate: 2026-09-02
+pubDate: 2026-05-15
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-05-17-one-codegen-many-formats.mdx
+++ b/src/content/posts/2026-05-17-one-codegen-many-formats.mdx
@@ -1,7 +1,7 @@
 ---
 title: "One codegen, many wire formats"
 slug: "one-codegen-many-formats"
-pubDate: 2026-09-16
+pubDate: 2026-05-17
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-05-19-clap-for-cpp.mdx
+++ b/src/content/posts/2026-05-19-clap-for-cpp.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Clap for C++: turning structs into command-line parsers"
 slug: "clap-for-cpp"
-pubDate: 2026-09-30
+pubDate: 2026-05-19
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-05-21-tiny-orm.mdx
+++ b/src/content/posts/2026-05-21-tiny-orm.mdx
@@ -1,7 +1,7 @@
 ---
 title: "A tiny ORM: struct to SQL via reflection"
 slug: "tiny-orm"
-pubDate: 2026-10-14
+pubDate: 2026-05-21
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-05-23-dependency-injection.mdx
+++ b/src/content/posts/2026-05-23-dependency-injection.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Autowired dependency injection: no container, just reflection"
 slug: "dependency-injection"
-pubDate: 2026-10-28
+pubDate: 2026-05-23
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-05-25-auto-mocks.mdx
+++ b/src/content/posts/2026-05-25-auto-mocks.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Auto-generated mocks from interfaces"
 slug: "auto-mocks"
-pubDate: 2026-11-11
+pubDate: 2026-05-25
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-05-27-define-aggregate.mdx
+++ b/src/content/posts/2026-05-27-define-aggregate.mdx
@@ -1,7 +1,7 @@
 ---
 title: "define_aggregate: synthesising types at compile time"
 slug: "define-aggregate"
-pubDate: 2026-11-25
+pubDate: 2026-05-27
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-05-29-qt-moc-replacement.mdx
+++ b/src/content/posts/2026-05-29-qt-moc-replacement.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Replacing Qt's MOC with reflection"
 slug: "qt-moc-replacement"
-pubDate: 2026-12-09
+pubDate: 2026-05-29
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-05-31-cross-language-comparison.mdx
+++ b/src/content/posts/2026-05-31-cross-language-comparison.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Reflection across languages: C++26 vs Rust, C#, Java, TypeScript, Go, Python"
 slug: "cross-language-comparison"
-pubDate: 2026-12-23
+pubDate: 2026-05-31
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-06-02-reflect-llmschema.mdx
+++ b/src/content/posts/2026-06-02-reflect-llmschema.mdx
@@ -1,7 +1,7 @@
 ---
 title: "reflect_llmschema: C++ functions to LLM tool-use schemas, at compile time"
 slug: "reflect-llmschema"
-pubDate: 2027-01-06
+pubDate: 2026-06-02
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-06-04-reflect-arbitrary.mdx
+++ b/src/content/posts/2026-06-04-reflect-arbitrary.mdx
@@ -1,7 +1,7 @@
 ---
 title: "reflect_arbitrary: property-based test generators, inferred from your types"
 slug: "reflect-arbitrary"
-pubDate: 2027-01-20
+pubDate: 2026-06-04
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-06-06-reflect-optics.mdx
+++ b/src/content/posts/2026-06-06-reflect-optics.mdx
@@ -1,7 +1,7 @@
 ---
 title: "reflect_optics: Haskell-style lenses for C++26"
 slug: "reflect-optics"
-pubDate: 2027-02-03
+pubDate: 2026-06-06
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-06-08-reflect-dx.mdx
+++ b/src/content/posts/2026-06-08-reflect-dx.mdx
@@ -1,7 +1,7 @@
 ---
 title: "reflect_dx: auto-generated debugger pretty-printers and docs"
 slug: "reflect-dx"
-pubDate: 2027-02-17
+pubDate: 2026-06-08
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-06-10-reflect-telemetry.mdx
+++ b/src/content/posts/2026-06-10-reflect-telemetry.mdx
@@ -1,7 +1,7 @@
 ---
 title: "reflect_telemetry: compile-time Prometheus metrics from annotated fields"
 slug: "reflect-telemetry"
-pubDate: 2027-03-03
+pubDate: 2026-06-10
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-06-12-reflect-tracing.mdx
+++ b/src/content/posts/2026-06-12-reflect-tracing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "reflect_tracing: zero-overhead spans on Maciek Gajewski's ring-buffer engine"
 slug: "reflect-tracing"
-pubDate: 2027-03-17
+pubDate: 2026-06-12
 author: filip-sajdak
 language: en
 kind: flagship

--- a/src/content/posts/2026-06-14-reflect-soa.mdx
+++ b/src/content/posts/2026-06-14-reflect-soa.mdx
@@ -1,7 +1,7 @@
 ---
 title: "reflect_soa: AoS → SoA → AoSoA, one struct, three layouts"
 slug: "reflect-soa"
-pubDate: 2027-03-31
+pubDate: 2026-06-14
 author: filip-sajdak
 language: en
 kind: flagship


### PR DESCRIPTION
## Summary

Re-stamps pubDate + renames file for posts 2-25 to every-2-days starting 2026-04-29 (Wed). Post 1 unchanged. Series concludes 2026-06-14 instead of 2027-03-31 -- a ~7-week run instead of ~11 months.

## What changes

| post | old pubDate | new pubDate |
|---|---|---|
| 2  | 2026-05-13 | 2026-04-29 |
| 3  | 2026-05-27 | 2026-05-01 |
| 4  | 2026-06-10 | 2026-05-03 |
| ... | ... | ... |
| 25 | 2027-03-31 | 2026-06-14 |

isPublished gating + PostLink + Buffer scheduled mode all work the same -- only the calendar slots shift.

## Buffer reschedule done out-of-band

The two scheduled posts for post 2 (LinkedIn + Facebook, both targeting 2026-05-13T08:00:00Z) were deleted via Buffer's deletePost mutation and recreated targeting **2026-04-29T08:00:00Z** (= 10:00 CEST):

- LinkedIn: 69ef99300a1f209cc7461c04
- Facebook: 69ef99310a1f209cc7461c2a

Visible in https://publish.buffer.com/calendar.

## Bundled

Cherry-picks the PR #14 buffer-script fix (mode field name + Facebook PostType metadata + verbose error formatter) so this branch can do the rescheduling without depending on the unmerged PR. **PR #14 should be closed as superseded after this merges.**

## Test plan

- [ ] Merge.
- [ ] Wait for the deploy.yml run.
- [ ] Confirm the new mdx filenames are in main and post 1's PostLink to first-reflection still renders as plain text (post 2 not yet at pubDate).
- [ ] On Wed 2026-04-29 ~07:00 UTC: site cron auto-publishes post 2.
- [ ] On Wed 2026-04-29 08:00 UTC: Buffer fires the two scheduled posts.
- [ ] Repeat for posts 3-25 every 2 days from there.