### PR TITLE
feat(safeguards): godbolt run-verify + link sweep + drift check (post-2 fire-drill response)

### DIFF
--- a/.claude/skills/publish-post/SKILL.md
+++ b/.claude/skills/publish-post/SKILL.md
@@ -62,13 +62,20 @@ git -C /Users/filipsajdak/dev/c++26 tag posts/<NN>@v1
 git -C /Users/filipsajdak/dev/c++26 push --follow-tags
 ```
 
-### 4. Generate Compiler Explorer permalinks
+### 4. Generate Compiler Explorer permalinks (with API run-verify)
 
 ```
 python3 scripts/shorten-examples.py --post <NN>-<slug-folder>
 ```
 
-This appends `<slug>.<variant>: { id, url, title }` entries to `src/data/godbolt-permalinks.yml` for every `.cpp` example. Idempotent -- variants that already have an `id` are skipped (use `--force` only if you want to re-shorten).
+For every example, the script now:
+1. POSTs the source to godbolt's `/api/compiler/<id>/compile` with `execute: true`. **Aborts** if the compile or program exit code is non-zero.
+2. Captures `stdout` into the YAML as `expected_output:` (used by the post-merge content-drift check).
+3. Shortens via the `/api/shortener` if there's no existing id (or if `--force`). Otherwise re-uses the existing id and just refreshes `expected_output` if it has drifted.
+
+The post-2 fire-drill informed this: the local container PASS doesn't catch CE-only failures, and a working shortlink id doesn't imply the code compiles today.
+
+`--no-run-verify` is available but you should never use it -- it disables the contract with readers.
 
 ### 5. Wire permalinks into the MDX
 
@@ -113,13 +120,16 @@ The script:
 
 The discussion link surfaces in `PostLayout`'s article meta as `· discuss` and in the post's own CTA paragraph.
 
-### 8. Build sanity check
+### 8. Build sanity check + link sweep + drift watch
 
 ```
 NODE_ENV=production npm run build
+python3 scripts/check-post-links.py --slug <slug>
 ```
 
-Abort on warnings or errors. Spot-check the output: `dist/posts/<slug>/index.html` exists, `dist/series/cpp26-reflection/index.html` lists the new post.
+`npm run build` must complete without warnings. `check-post-links.py` greps every `href` in the new post's HTML and verifies internal links resolve in `dist/`, plus HEAD-checks external links. **Abort on any failure** -- this catches forward-refs that escaped PostLink wrapping (the failure mode where a live post has a broken link to an unshipped post).
+
+If any internal link points to a post that hasn't shipped yet, wrap that link in `<PostLink slug="...">label</PostLink>` so it renders as plain text until the target's pubDate, then auto-becomes a live link.
 
 ### 9. Three atomic commits
 
@@ -152,7 +162,7 @@ Co-Authored-By: ..."
 
 If a step has nothing to add (e.g. no cross-refs were warranted), drop that commit.
 
-### 10. Push and open PR
+### 10. Push, open PR, schedule pre-Buffer guard, and queue a post-merge drift check
 
 ```
 git push -u origin mr/<NN>-<slug>
@@ -161,11 +171,20 @@ gh pr create --base main --head mr/<NN>-<slug> \
   --body "..."
 ```
 
-PR body should follow the template in `~/.claude/plans/lets-split-all-the-temporal-oasis.md` (Summary / Verification / Test plan sections).
+PR body follows the template in `~/.claude/plans/lets-split-all-the-temporal-oasis.md`.
 
-Print the PR URL and remind the user that:
+**Mandatory automated safeguards** (don't skip; the post-2 fire-drill happened because these weren't in place):
+
+1. **Pre-Buffer publish guard.** Schedule a one-shot cron via the `CronCreate` tool to fire 15 min before the Buffer schedule time (= post's pubDate at 07:45 UTC). The cron prompt should: (a) `curl -sI` the post URL, (b) on 404, manually trigger `gh workflow run deploy.yml`, watch it to completion, re-verify, (c) on STILL 404, escalate by reading the build log and reporting. Persist with `durable: true` so it survives session restarts.
+
+2. **Post-merge content-drift check.** After the user merges the PR (and the deploy run completes), Claude must run `python3 scripts/check-live-content.py --slug <slug>`. This catches the post-2 failure mode where the godbolt id was wired in on a branch but lost in the merge. If drift is found (TODO id in live HTML, frontmatter title/summary mismatch, missing godbolt link, etc.), open + auto-merge a hotfix PR.
+
+3. **Discussion thread auto-create.** Before opening the PR, run `python3 scripts/create-discussion.py --slug <slug>` (idempotent: skips if frontmatter already has `discussion:`). This patches the mdx so the discussion URL is in the frontmatter + in the body's CTA before the PR opens. Future PostLayout renders show a `· discuss` link in the article meta.
+
+Print the PR URL + the cron job id + the discussion URL. Remind the user that:
 - The post stays invisible in production until `pubDate` (daily cron at 07:00 UTC).
 - After merge, run `/advertise-post <slug>` to generate the LinkedIn + Facebook material.
+- The pre-Buffer cron will auto-fix any cron-vs-Buffer race.
 
 ## Reuse
 

--- a/scripts/check-live-content.py
+++ b/scripts/check-live-content.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Post-merge content-drift check on the live deployed site.
+
+Run AFTER a publish PR merges + the deploy.yml run completes. Fetches
+the live post HTML and asserts:
+
+  - The page is reachable (HTTP 200).
+  - No `id="TODO..."` GodboltEmbed placeholders survived the merge.
+    (Caught the post-2 'wire-in lost between branches' failure.)
+  - The page's heading + summary match the local mdx frontmatter
+    (catches stale CDN / wrong commit / wrong post deployed).
+  - The expected godbolt link appears (matches the YAML).
+  - The expected `discussion:` URL (if frontmatter has one) is in the
+    page body.
+
+Usage:
+    scripts/check-live-content.py --slug first-reflection
+    scripts/check-live-content.py --slug splicing --base-url https://wrocpp.github.io
+
+Exits non-zero on any drift; prints a punch-list of what's wrong.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("error: PyYAML not installed")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_BASE = "https://wrocpp.github.io"
+
+
+def fetch(url: str, timeout: int = 15) -> tuple[int, str]:
+    req = urllib.request.Request(url, headers={
+        "User-Agent": "wrocpp-drift-check/1.0",
+        "Accept": "text/html,*/*",
+    })
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as e:
+        return e.code, ""
+
+
+def post_frontmatter(slug: str) -> dict:
+    posts = sorted((REPO_ROOT / "src/content/posts").glob(f"*-{slug}.mdx"))
+    if not posts:
+        sys.exit(f"error: no mdx for slug {slug!r}")
+    text = posts[0].read_text()
+    end = text.find("\n---", 3)
+    return yaml.safe_load(text[3:end]) or {}
+
+
+def godbolt_ids_for(slug: str) -> list[str]:
+    yml = REPO_ROOT / "src/data/godbolt-permalinks.yml"
+    if not yml.exists():
+        return []
+    data = yaml.safe_load(yml.read_text()) or {}
+    entries = data.get(slug, {}) or {}
+    return [v.get("id") for v in entries.values() if isinstance(v, dict) and v.get("id")]
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--slug", required=True)
+    p.add_argument("--base-url", default=DEFAULT_BASE)
+    args = p.parse_args()
+
+    fm = post_frontmatter(args.slug)
+    url = f"{args.base_url}/posts/{args.slug}/"
+    print(f"--> fetching {url}", file=sys.stderr)
+    status, html = fetch(url)
+    fails: list[str] = []
+
+    if status != 200:
+        fails.append(f"HTTP {status} (expected 200) -- post not live yet, or pubDate gating, or deploy stale")
+        print(f"\nFAIL: {fails[0]}")
+        return 2
+
+    # 1. No TODO placeholders survived.
+    todos = re.findall(r'id="(TODO[^"]*)"', html)
+    if todos:
+        fails.append(f"GodboltEmbed placeholder ids on live page: {todos}")
+
+    # Also catch the rendered placeholder card (for the Astro-rendered case
+    # where the id starts with TODO and the component renders the gray
+    # "Click-to-run coming soon" card).
+    if "PERMALINK PENDING" in html or "Click-to-run coming soon" in html:
+        fails.append("rendered 'PERMALINK PENDING' / 'Click-to-run coming soon' card on live page")
+
+    # 2. Title + summary match.
+    title = fm.get("title", "")
+    if title and title not in html:
+        fails.append(f"frontmatter title {title!r} not found in live HTML")
+    summary = fm.get("summary", "")
+    if summary and summary[:60] not in html:
+        fails.append(f"frontmatter summary not found in live HTML (first 60 chars: {summary[:60]!r})")
+
+    # 3. Godbolt ids appear (at least one).
+    ids = godbolt_ids_for(args.slug)
+    if ids:
+        present = [i for i in ids if f"godbolt.org/z/{i}" in html]
+        missing = [i for i in ids if i not in present]
+        if not present:
+            fails.append(f"no godbolt id from YAML appears on the page (expected one of: {ids})")
+        elif missing:
+            print(f"note: not all variants linked from page (ok if not every variant has a GodboltEmbed): missing {missing}",
+                  file=sys.stderr)
+
+    # 4. Discussion URL (if frontmatter has one).
+    discussion = fm.get("discussion")
+    if discussion and discussion not in html:
+        fails.append(f"frontmatter discussion: {discussion} not linked from live page")
+
+    if fails:
+        print("\nFAIL:")
+        for f in fails:
+            print(f"  - {f}")
+        return 1
+
+    print("ok   live post matches local frontmatter + YAML")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-post-links.py
+++ b/scripts/check-post-links.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Link-resolution sweep on the production-built dist for one post.
+
+Run AFTER `npm run build`; greps the post's HTML for every `href` and
+verifies:
+
+  - relative URLs (no scheme) -> the path exists in dist/
+  - https://wrocpp.github.io/... -> the path exists in dist/ (same site)
+  - external https?://... -> HEAD-fetched, must return 2xx/3xx (not 404)
+
+Catches the failure mode where a forward reference to /posts/<slug>/
+slipped past PostLink (which would gate it to plain text until that
+post's pubDate). Without this check, the post-2 fire-drill scenario
+plays out for every post: live page, broken internal link.
+
+Usage:
+    scripts/check-post-links.py --slug why-cpp26-reflection-matters
+    scripts/check-post-links.py --slug splicing --no-external
+
+Exits non-zero if any link fails to resolve.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DIST = REPO_ROOT / "dist"
+SITE_HOST = "wrocpp.github.io"
+
+
+def post_html(slug: str) -> Path:
+    p = DIST / "posts" / slug / "index.html"
+    if not p.exists():
+        sys.exit(f"error: {p} not in dist -- did `npm run build` run? "
+                 f"Or post is gated by isPublished (pubDate in future).")
+    return p
+
+
+def hrefs(html: str) -> list[str]:
+    return re.findall(r'href="([^"]+)"', html)
+
+
+def head_ok(url: str, timeout: float = 8) -> tuple[bool, int | str]:
+    """HEAD-fetch a URL. Some servers reject HEAD; fall back to GET range
+    bytes 0-0 if HEAD returns 4xx/5xx."""
+    for method in ("HEAD", "GET"):
+        try:
+            req = urllib.request.Request(url, method=method, headers={
+                "User-Agent": "wrocpp-link-check/1.0",
+                "Accept": "*/*",
+            })
+            if method == "GET":
+                req.add_header("Range", "bytes=0-0")
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return resp.status < 400, resp.status
+        except urllib.error.HTTPError as e:
+            if method == "HEAD" and e.code in (405, 403):
+                continue
+            return False, e.code
+        except (urllib.error.URLError, TimeoutError) as e:
+            return False, str(e)[:120]
+    return False, "all-methods-failed"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--slug", required=True)
+    p.add_argument("--no-external", action="store_true",
+                   help="skip http(s) URLs to other domains (fastest mode)")
+    args = p.parse_args()
+
+    html = post_html(args.slug).read_text()
+    seen_internal: set[str] = set()
+    seen_external: set[str] = set()
+    fails: list[tuple[str, str]] = []
+
+    for href in hrefs(html):
+        if href.startswith("#") or href.startswith("mailto:") or href.startswith("tel:"):
+            continue
+        if href.startswith("/") or href.startswith(f"https://{SITE_HOST}"):
+            # Treat as internal: strip host + query/fragment, look in dist.
+            path = href.replace(f"https://{SITE_HOST}", "")
+            path = path.split("?", 1)[0].split("#", 1)[0]
+            if path in seen_internal:
+                continue
+            seen_internal.add(path)
+            target = DIST / path.lstrip("/")
+            # Astro emits /<dir>/index.html for trailing-slash routes; map.
+            candidates = [target, target / "index.html"]
+            if not any(c.exists() for c in candidates):
+                fails.append((href, f"missing in dist: {target.relative_to(DIST)}"))
+                continue
+            print(f"ok   internal {href}")
+            continue
+
+        if not href.startswith(("http://", "https://")):
+            continue  # skip exotic schemes
+
+        if args.no_external:
+            continue
+        if href in seen_external:
+            continue
+        seen_external.add(href)
+        ok, status = head_ok(href)
+        marker = "ok  " if ok else "FAIL"
+        print(f"{marker} external {href}  [{status}]")
+        if not ok:
+            fails.append((href, f"http {status}"))
+
+    print()
+    print(f"checked: {len(seen_internal)} internal, {len(seen_external)} external")
+    if fails:
+        print(f"\n{len(fails)} failure(s):")
+        for url, why in fails:
+            print(f"  - {url}\n      {why}")
+        return 1
+    print("all links resolve.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shorten-examples.py
+++ b/scripts/shorten-examples.py
@@ -33,6 +33,7 @@ CPP26_ROOT = Path("/Users/filipsajdak/dev/c++26")
 COMPILER_ID = "clang_bb_p2996"
 COMPILER_OPTIONS = "-std=c++26 -freflection-latest -stdlib=libc++"
 SHORTENER_URL = "https://godbolt.org/api/shortener"
+COMPILE_URL = f"https://godbolt.org/api/compiler/{COMPILER_ID}/compile"
 
 
 def slug_from_post(post_arg: str) -> tuple[str, str]:
@@ -94,11 +95,56 @@ def shorten(source: str, title: str) -> dict:
     return {"id": short_id, "url": url, "title": title}
 
 
+def compile_and_run(source: str) -> tuple[bool, str, str]:
+    """Compile + execute the source via godbolt's API.
+
+    Returns (ok, stdout, stderr_or_compile_log). `ok` is True only if the
+    compiler exited 0 AND the program exited 0. We use this as a gate
+    BEFORE creating the shortlink: if the code doesn't actually run on
+    Compiler Explorer, the published post would lie to readers.
+
+    The post-2 fire-drill informed this: the local container PASS doesn't
+    catch CE-only failures (different libstdc++ headers, missing -include,
+    etc.) and a working shortlink doesn't imply the code compiles.
+    """
+    payload = {
+        "source": source,
+        "options": {
+            "userArguments": COMPILER_OPTIONS,
+            "filters": {"execute": True},
+        },
+    }
+    req = urllib.request.Request(
+        COMPILE_URL,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        return False, "", f"godbolt http {e.code}: {e.read().decode(errors='replace')[:300]}"
+    compile_code = body.get("code", -1)
+    compile_stderr = "\n".join(x.get("text", "") for x in body.get("stderr", []))
+    if compile_code != 0:
+        return False, "", f"compile failed (code={compile_code}):\n{compile_stderr[:600]}"
+    exec_result = body.get("execResult") or {}
+    exec_code = exec_result.get("code", -1)
+    exec_stdout = "\n".join(x.get("text", "") for x in exec_result.get("stdout", []))
+    exec_stderr = "\n".join(x.get("text", "") for x in exec_result.get("stderr", []))
+    if exec_code != 0:
+        return False, exec_stdout, f"program exited {exec_code}:\n{exec_stderr[:600]}"
+    return True, exec_stdout, ""
+
+
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--post", required=True, help="post folder (e.g. 02-first-reflection)")
     p.add_argument("--force", action="store_true", help="overwrite existing entries")
     p.add_argument("--dry-run", action="store_true", help="print what would change")
+    p.add_argument("--no-run-verify", action="store_true",
+                   help="skip the godbolt API compile+execute gate (NOT RECOMMENDED)")
     args = p.parse_args()
 
     nn_slug, slug = slug_from_post(args.post)
@@ -120,17 +166,49 @@ def main() -> int:
     for src in sources:
         variant = src.stem  # e.g. "teaser_peel"
         existing = yaml_data[slug].get(variant) or {}
-        if existing.get("id") and not args.force:
-            print(f"skip  {slug}.{variant}  (id={existing['id']})")
-            continue
         title = existing.get("title") or variant.replace("_", " ").capitalize()
         source_text = src.read_text()
+
+        already_shortened = bool(existing.get("id")) and not args.force
         if args.dry_run:
-            print(f"DRY   {slug}.{variant}  ({src.name}, {len(source_text)} chars)")
+            verb = "VERIFY" if already_shortened else "DRY"
+            print(f"{verb:6} {slug}.{variant}  ({src.name}, {len(source_text)} chars)")
             continue
+
+        # Compile + execute via godbolt API BEFORE shortening (or before
+        # accepting an existing shortlink as still-good). Captures stdout
+        # into `expected_output` for content-drift / regression alerts.
+        # The post-2 fire-drill informed this: a working shortlink ID
+        # doesn't imply the code compiles on CE today.
+        stdout = ""
+        if not args.no_run_verify:
+            print(f"verify  {slug}.{variant}  ->", end=" ", flush=True)
+            ok, stdout, err = compile_and_run(source_text)
+            if not ok:
+                print("FAIL")
+                sys.exit(f"\nCE verification failed for {src.name}:\n{err}")
+            print(f"OK (stdout: {len(stdout)} chars)")
+
+        if already_shortened:
+            # Re-verify path: keep the existing shortlink id, just
+            # refresh expected_output if it's missing or has drifted.
+            old_out = existing.get("expected_output")
+            if old_out == stdout:
+                print(f"skip    {slug}.{variant}  (id={existing['id']}, output unchanged)")
+                continue
+            existing["expected_output"] = stdout
+            yaml_data[slug][variant] = existing
+            kind = "added" if not old_out else "updated"
+            print(f"OK      {slug}.{variant}  ({kind} expected_output for id={existing['id']})")
+            changed = True
+            continue
+
+        # Fresh shortener call (no existing id, or --force).
         result = shorten(source_text, title)
+        if stdout:
+            result["expected_output"] = stdout
         yaml_data[slug][variant] = result
-        print(f"OK    {slug}.{variant}  -> {result['url']}")
+        print(f"OK      {slug}.{variant}  -> {result['url']}")
         changed = True
 
     if changed and not args.dry_run:

--- a/src/data/godbolt-permalinks.yml
+++ b/src/data/godbolt-permalinks.yml
@@ -12,20 +12,56 @@ why-cpp26-reflection-matters:
     id: n4eK93vfv
     url: https://godbolt.org/z/n4eK93vfv
     title: 40-line JSON serializer with reflection
+    expected_output: '{"name":"Filip","age":40,"admin":true,"home":{"city":"Warsaw","postal_code":12345}}'
   teaser_peel:
     id: MzM4bh3rj
     url: https://godbolt.org/z/MzM4bh3rj
     title: "Peel-first variant \u2014 first iteration hoisted to compile time"
+    expected_output: '{"name":"Filip","age":40,"admin":true,"home":{"city":"Warsaw","postal_code":12345}}'
   teaser_annotated:
     id: 97WdeKs7v
     url: https://godbolt.org/z/97WdeKs7v
     title: "Annotated serializer \u2014 rename, skip, skip-if-empty, rename_all"
+    expected_output: '{"userName":"filip","id":42,"email":"filip@example.com","bio":"hello","isAdmin":true}
+
+      {"userName":"anon","id":7,"email":"a@b.c","isAdmin":false}'
   teaser_formats:
     id: WKhjGxE7K
     url: https://godbolt.org/z/WKhjGxE7K
     title: "One reflection walk, three formats: JSON \xB7 YAML \xB7 XML"
+    expected_output: "--- JSON ---\n{\"userName\":\"filip\",\"id\":42,\"email\":\"filip@example.com\",\"isAdmin\":true,\"\
+      homeAddress\":{\"city\":\"Warsaw\",\"postal_code\":12345}}\n\n--- YAML ---\nuserName: filip\nid: 42\nemail: filip@example.com\n\
+      isAdmin: true\nhomeAddress: \n  city: Warsaw\n  postal_code: 12345\n\n--- XML  ---\n<userName>filip</userName><id>42</id><email>filip@example.com</email><isAdmin>true</isAdmin><homeAddress><city>Warsaw</city><postal_code>12345</postal_code></homeAddress>"
 first-reflection:
   describe:
     id: bq9WjeeM5
     url: https://godbolt.org/z/bq9WjeeM5
     title: Describe
+    expected_output: 'Point:
+
+      x: int
+
+      y: int
+
+
+      Line:
+
+      a: Point
+
+      b: Point
+
+      name: basic_string<char, char_traits<char>, allocator<char>>
+
+      '
+splicing:
+  splice_basics:
+    id: TnMx1Ys5b
+    url: https://godbolt.org/z/TnMx1Ys5b
+    title: Splice basics
+    expected_output: "read<Point::x>: 3\nPoint:\n  x = 3\n  y = 4"
+template-for-expansion-statements:
+  dump:
+    id: j9vWKaEG6
+    url: https://godbolt.org/z/j9vWKaEG6
+    title: Dump
+    expected_output: "Point:\n  x = 3\n  y = 4\ntuple element: 1\ntuple element: 2.5\ntuple element: c"


### PR DESCRIPTION
Hardens the publish pipeline against the four root causes of the post-2 fire-drill (godbolt id reverted from main; cron ran late; Buffer linked to 404; no automated rollback). Three small scripts + skill update; no behaviour change for posts already on main. Detail in the commit message.