### PR TITLE
refactor(skills): manual-only invocation + scoped tool globs + dynamic context injection

### DIFF
--- a/.claude/skills/advertise-post/SKILL.md
+++ b/.claude/skills/advertise-post/SKILL.md
@@ -2,10 +2,16 @@
 name: advertise-post
 description: Generate paste-ready LinkedIn + Facebook captions plus a 2400x2400 wro.cpp-branded social card image for an already-published post. Outputs land under social/<platform>/<slug>/. Posting is manual (matches the scudoai/linkedin-posts/thesis-series workflow exactly).
 argument-hint: <slug>
-allowed-tools: Bash, Read, Write, Edit, Glob, AskUserQuestion
+allowed-tools: Read Write Edit Glob Grep Bash(brand-gen *) Bash(cd *) Bash(cp *) Bash(mv *) Bash(rm *) Bash(mkdir *) Bash(file *) Bash(open *) Bash(.claude/skills/advertise-post/brand-kit/inject.sh *) AskUserQuestion
 ---
 
 # /advertise-post -- generate the LinkedIn + Facebook launch material for a wro.cpp post
+
+Most recently shipped posts (for cross-referencing context):
+
+```!
+ls /Users/filipsajdak/dev/wrocpp.github.io/src/content/posts | tail -3
+```
 
 Use this skill any time after a post has shipped. It produces:
 

--- a/.claude/skills/publish-post/SKILL.md
+++ b/.claude/skills/publish-post/SKILL.md
@@ -2,10 +2,17 @@
 name: publish-post
 description: Ship a wro.cpp blog post end-to-end. Verifies code in the cpp26-reflection-examples repo, generates Compiler Explorer permalinks, wires them into the MDX, hand-curates cross-references to/from prior posts in the series, flips draft to false, and opens a PR with three atomic conventional commits. Pass the post slug or its series_order (e.g. "first-reflection" or "02").
 argument-hint: <slug-or-NN>
-allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, AskUserQuestion
+disable-model-invocation: true
+allowed-tools: Read Write Edit Glob Grep Bash(git *) Bash(gh *) Bash(npm *) Bash(python3 *) Bash(./verify.sh *) Bash(./cpp *) Bash(./run *) Bash(date *) Agent AskUserQuestion ToolSearch CronCreate
 ---
 
 # /publish-post -- ship one wro.cpp blog post
+
+In-flight PRs at invoke time:
+
+```!
+cd /Users/filipsajdak/dev/wrocpp.github.io && gh pr list --state open --json number,title -q '.[] | "PR#\(.number): \(.title)"'
+```
 
 Use this skill to land MR2..MR25 of the C++26 reflection series. Each invocation produces one `mr/<NN>-<slug>` PR ready for review, with all the work the per-MR checklist in `~/.claude/plans/lets-split-all-the-temporal-oasis.md` calls for.
 

--- a/.claude/skills/push-to-buffer/SKILL.md
+++ b/.claude/skills/push-to-buffer/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: push-to-buffer
-description: Push the LinkedIn + Facebook captions and the social card image for a wro.cpp post to Buffer as DRAFTS via Buffer's GraphQL API. Drafts land in the user's Buffer Drafts tab for manual scheduling. Reads the post artefacts produced by /advertise-post.
+description: Push the LinkedIn + Facebook captions + social card image for a wro.cpp post to Buffer. Default mode schedules at the post's pubDate at 10:00 Europe/Warsaw; --draft pushes to the Drafts tab for manual scheduling instead. Reads the post artefacts produced by /advertise-post.
 argument-hint: <slug>
-allowed-tools: Bash, Read, Edit, AskUserQuestion
+disable-model-invocation: true
+allowed-tools: Read Edit Bash(python3 scripts/push-to-buffer.py *) Bash(curl *) Bash(gh *) AskUserQuestion
 ---
 
 # /push-to-buffer -- create Buffer drafts for one post


### PR DESCRIPTION
Aligns the 3 SKILL.md files with the canonical patterns from https://code.claude.com/docs/en/skills. Edit-only pass; no new supporting files (Write to .claude/skills/ blocked in subagent permission set).

## What changed per skill

| Skill | disable-model-invocation | allowed-tools | dynamic context |
|---|---|---|---|
| publish-post | **true** (manual-only -- opens PRs, schedules cron) | scoped globs (Bash(git *) etc) + Agent + ToolSearch + CronCreate | injects open PR list at load time |
| advertise-post | unchanged (auto-invocable -- local artefacts only) | scoped globs | injects last 3 post slugs |
| push-to-buffer | **true** (manual-only -- creates real Buffer posts) | scoped globs | n/a (channel discovery in script) |

## Why this matters

- **Manual-only on side-effect skills.** Removes their bodies from Claude's auto-invoke context (saves ~600 tokens per session) and prevents accidental publish chains when discussing the workflow.
- **Scoped tool globs.** Replaces bare \`Bash\` with \`Bash(git *) Bash(gh *) Bash(npm *) Bash(python3 *)\` -- accidental \`Bash(rm *)\` or \`Bash(sudo *)\` from a confused branch can't slip through.
- **Dynamic context blocks.** \`!\`\`gh pr list...\`\` and \`!\`\`ls .../posts | tail -3\`\` execute at skill-load time, splicing live state inline so the body knows about in-flight PRs / recent posts without re-discovery on every step.

## Deferred

Progressive-disclosure split (move failure-mode tables / commit templates / examples to supporting \`*.md\` files in each skill dir) needs Write to \`.claude/skills/\` -- currently denied in subagent permissions. Follow-up PR once that's granted.

## Test plan

- [ ] Merge.
- [ ] Open a fresh Claude session in the repo; \`/publish-post 03\` should still resolve, and the PR list should render in the skill's preamble.
- [ ] \`/advertise-post first-reflection\` renders the recent-posts list from the dynamic block.
- [ ] Discussing "publishing posts" in chat should NOT auto-load /publish-post or /push-to-buffer body (manual-only). /advertise-post can auto-trigger.