### PR TITLE
feat: GCC 16.1 parallel godbolt links + footnote in posts 1 + 2

### DIFF
--- a/scripts/shorten-examples.py
+++ b/scripts/shorten-examples.py
@@ -30,10 +30,46 @@ except ImportError:
 REPO_ROOT = Path(__file__).resolve().parent.parent
 YAML_PATH = REPO_ROOT / "src" / "data" / "godbolt-permalinks.yml"
 CPP26_ROOT = Path("/Users/filipsajdak/dev/c++26")
-COMPILER_ID = "clang_bb_p2996"
-COMPILER_OPTIONS = "-std=c++26 -freflection-latest -stdlib=libc++"
 SHORTENER_URL = "https://godbolt.org/api/shortener"
-COMPILE_URL = f"https://godbolt.org/api/compiler/{COMPILER_ID}/compile"
+
+# Per-toolchain compile/shorten profile. Two compilers ship C++26 reflection
+# as of 2026-05-01: the Bloomberg clang-p2996 fork (the series's reference
+# container) and GCC 16.1 (released April 2026, hosted on Compiler Explorer
+# as `g161`). Posts gain parallel godbolt links so readers can pick either.
+COMPILER_PROFILES = {
+    "clang": {
+        "id": "clang_bb_p2996",
+        "options": "-std=c++26 -freflection-latest -stdlib=libc++",
+        "yaml_id_key": "id",
+        "yaml_url_key": "url",
+        "yaml_output_key": "expected_output",
+        # No source rewrite needed -- clang-p2996 ships <experimental/meta>.
+        "source_rewrites": [],
+    },
+    "gcc": {
+        "id": "g161",
+        "options": "-std=c++26 -freflection",
+        "yaml_id_key": "gcc_id",
+        "yaml_url_key": "gcc_url",
+        "yaml_output_key": "gcc_expected_output",
+        # GCC 16.1 ships only <meta>, not the <experimental/meta> alias.
+        # Header shim: rewrite the include line on the fly so the same
+        # source compiles against both toolchains. Authoritative .cpp on
+        # disk stays clang-shaped (uses <experimental/meta>).
+        "source_rewrites": [("<experimental/meta>", "<meta>")],
+    },
+}
+
+
+def compile_url(profile: dict) -> str:
+    return f"https://godbolt.org/api/compiler/{profile['id']}/compile"
+
+
+def apply_rewrites(source: str, profile: dict) -> str:
+    out = source
+    for old, new in profile["source_rewrites"]:
+        out = out.replace(old, new)
+    return out
 
 
 def slug_from_post(post_arg: str) -> tuple[str, str]:
@@ -65,9 +101,9 @@ def slug_from_post(post_arg: str) -> tuple[str, str]:
     sys.exit(f"error: no mdx post with series_order={nn} found in {posts_dir}")
 
 
-def shorten(source: str, title: str) -> dict:
-    """Hit godbolt's shortener with one source file. Returns the parsed
-    {id, url, title} we want to write into the YAML."""
+def shorten(source: str, title: str, profile: dict) -> dict:
+    """Hit godbolt's shortener with one source file under the given
+    compiler profile. Returns the parsed {id, url, title}."""
     payload = {
         "sessions": [
             {
@@ -75,7 +111,7 @@ def shorten(source: str, title: str) -> dict:
                 "language": "c++",
                 "source": source,
                 "compilers": [
-                    {"id": COMPILER_ID, "options": COMPILER_OPTIONS}
+                    {"id": profile["id"], "options": profile["options"]}
                 ],
             }
         ]
@@ -95,27 +131,24 @@ def shorten(source: str, title: str) -> dict:
     return {"id": short_id, "url": url, "title": title}
 
 
-def compile_and_run(source: str) -> tuple[bool, str, str]:
-    """Compile + execute the source via godbolt's API.
+def compile_and_run(source: str, profile: dict) -> tuple[bool, str, str]:
+    """Compile + execute the source via godbolt's API under the given
+    compiler profile.
 
     Returns (ok, stdout, stderr_or_compile_log). `ok` is True only if the
-    compiler exited 0 AND the program exited 0. We use this as a gate
-    BEFORE creating the shortlink: if the code doesn't actually run on
-    Compiler Explorer, the published post would lie to readers.
-
-    The post-2 fire-drill informed this: the local container PASS doesn't
-    catch CE-only failures (different libstdc++ headers, missing -include,
-    etc.) and a working shortlink doesn't imply the code compiles.
+    compiler exited 0 AND the program exited 0. Used as a gate BEFORE
+    creating the shortlink: if the code doesn't actually run on Compiler
+    Explorer, the published post would lie to readers.
     """
     payload = {
         "source": source,
         "options": {
-            "userArguments": COMPILER_OPTIONS,
+            "userArguments": profile["options"],
             "filters": {"execute": True},
         },
     }
     req = urllib.request.Request(
-        COMPILE_URL,
+        compile_url(profile),
         data=json.dumps(payload).encode("utf-8"),
         headers={"Content-Type": "application/json", "Accept": "application/json"},
         method="POST",
@@ -145,7 +178,14 @@ def main() -> int:
     p.add_argument("--dry-run", action="store_true", help="print what would change")
     p.add_argument("--no-run-verify", action="store_true",
                    help="skip the godbolt API compile+execute gate (NOT RECOMMENDED)")
+    p.add_argument("--compiler", choices=["clang", "gcc", "both"], default="both",
+                   help="which compiler profile(s) to shorten + verify against (default: both)")
     args = p.parse_args()
+
+    profiles_to_run = (
+        list(COMPILER_PROFILES.values()) if args.compiler == "both"
+        else [COMPILER_PROFILES[args.compiler]]
+    )
 
     nn_slug, slug = slug_from_post(args.post)
     examples_dir = CPP26_ROOT / "posts" / nn_slug / "examples"
@@ -169,47 +209,60 @@ def main() -> int:
         title = existing.get("title") or variant.replace("_", " ").capitalize()
         source_text = src.read_text()
 
-        already_shortened = bool(existing.get("id")) and not args.force
-        if args.dry_run:
-            verb = "VERIFY" if already_shortened else "DRY"
-            print(f"{verb:6} {slug}.{variant}  ({src.name}, {len(source_text)} chars)")
-            continue
+        # Loop per compiler profile. clang and gcc each have their own YAML
+        # keys (id/url/expected_output vs gcc_id/gcc_url/gcc_expected_output)
+        # so the entry can carry both in parallel.
+        for profile in profiles_to_run:
+            id_key = profile["yaml_id_key"]
+            url_key = profile["yaml_url_key"]
+            output_key = profile["yaml_output_key"]
+            label = f"{slug}.{variant} [{profile['id']}]"
+            already_shortened = bool(existing.get(id_key)) and not args.force
 
-        # Compile + execute via godbolt API BEFORE shortening (or before
-        # accepting an existing shortlink as still-good). Captures stdout
-        # into `expected_output` for content-drift / regression alerts.
-        # The post-2 fire-drill informed this: a working shortlink ID
-        # doesn't imply the code compiles on CE today.
-        stdout = ""
-        if not args.no_run_verify:
-            print(f"verify  {slug}.{variant}  ->", end=" ", flush=True)
-            ok, stdout, err = compile_and_run(source_text)
-            if not ok:
-                print("FAIL")
-                sys.exit(f"\nCE verification failed for {src.name}:\n{err}")
-            print(f"OK (stdout: {len(stdout)} chars)")
-
-        if already_shortened:
-            # Re-verify path: keep the existing shortlink id, just
-            # refresh expected_output if it's missing or has drifted.
-            old_out = existing.get("expected_output")
-            if old_out == stdout:
-                print(f"skip    {slug}.{variant}  (id={existing['id']}, output unchanged)")
+            if args.dry_run:
+                verb = "VERIFY" if already_shortened else "DRY"
+                print(f"{verb:6} {label}  ({src.name}, {len(source_text)} chars)")
                 continue
-            existing["expected_output"] = stdout
-            yaml_data[slug][variant] = existing
-            kind = "added" if not old_out else "updated"
-            print(f"OK      {slug}.{variant}  ({kind} expected_output for id={existing['id']})")
-            changed = True
-            continue
 
-        # Fresh shortener call (no existing id, or --force).
-        result = shorten(source_text, title)
-        if stdout:
-            result["expected_output"] = stdout
-        yaml_data[slug][variant] = result
-        print(f"OK      {slug}.{variant}  -> {result['url']}")
-        changed = True
+            # Apply per-profile source rewrites (e.g. <experimental/meta>
+            # -> <meta> for GCC). Authoritative .cpp on disk is unchanged.
+            profile_source = apply_rewrites(source_text, profile)
+
+            stdout = ""
+            if not args.no_run_verify:
+                print(f"verify  {label}  ->", end=" ", flush=True)
+                ok, stdout, err = compile_and_run(profile_source, profile)
+                if not ok:
+                    print("FAIL")
+                    sys.exit(f"\nCE verification failed for {src.name} on {profile['id']}:\n{err}")
+                print(f"OK (stdout: {len(stdout)} chars)")
+
+            if already_shortened:
+                old_out = existing.get(output_key)
+                if old_out == stdout:
+                    print(f"skip    {label}  (id={existing[id_key]}, output unchanged)")
+                    continue
+                existing[output_key] = stdout
+                yaml_data[slug][variant] = existing
+                kind = "added" if not old_out else "updated"
+                print(f"OK      {label}  ({kind} {output_key} for id={existing[id_key]})")
+                changed = True
+                continue
+
+            # Fresh shortener call.
+            result = shorten(profile_source, title, profile)
+            # Re-key the response to per-profile YAML keys, then merge into
+            # the existing entry so clang and gcc fields coexist.
+            entry = dict(existing)
+            entry["title"] = title
+            entry[id_key] = result["id"]
+            entry[url_key] = result["url"]
+            if stdout:
+                entry[output_key] = stdout
+            yaml_data[slug][variant] = entry
+            existing = entry
+            print(f"OK      {label}  -> {result['url']}")
+            changed = True
 
     if changed and not args.dry_run:
         # Preserve the file header by re-reading and only rewriting from the

--- a/src/components/GodboltEmbed.astro
+++ b/src/components/GodboltEmbed.astro
@@ -12,24 +12,36 @@
  *   <GodboltEmbed id="n4eK93vfv" title="40-line JSON serializer" />
  */
 interface Props {
-  /** Short-link ID from godbolt.org/z/<ID>. Prefix `TODO` → placeholder mode. */
+  /** clang-p2996 short-link ID (godbolt.org/z/<ID>). Prefix `TODO` -> placeholder. */
   id: string;
+  /**
+   * Optional GCC 16.1 short-link ID. When set, a second "Run on GCC 16.1"
+   * button appears below the clang one (blue accent rule instead of orange).
+   * Set when GCC produces equivalent output for the example -- not all
+   * P2996 corners agree across the two implementations as of 2026-05-01.
+   */
+  gcc_id?: string;
   /** Headline for the card. */
   title?: string;
   /** Override the playground repo link shown in placeholder mode. */
   fallbackHref?: string;
-  /** Subtitle line. Defaults to the pinned compiler + flags. */
+  /** Subtitle for the clang button. Defaults to pinned compiler + flags. */
   subtitle?: string;
+  /** Subtitle for the GCC button. */
+  gcc_subtitle?: string;
 }
 const {
   id,
+  gcc_id,
   title = 'Run this example',
   subtitle = 'clang_bb_p2996 · -std=c++26 -freflection-latest -stdlib=libc++',
+  gcc_subtitle = 'g161 (GCC 16.1) · -std=c++26 -freflection',
   fallbackHref = 'https://github.com/wrocpp/cpp26-reflection-examples',
 } = Astro.props;
 
 const isPlaceholder = id.startsWith('TODO') || id === 'placeholder';
 const href = `https://godbolt.org/z/${id}`;
+const gccHref = gcc_id ? `https://godbolt.org/z/${gcc_id}` : null;
 ---
 {isPlaceholder ? (
   <div class="ce-cta ce-cta--placeholder">
@@ -42,13 +54,37 @@ const href = `https://godbolt.org/z/${id}`;
     </div>
   </div>
 ) : (
-  <a class="ce-cta" href={href} target="_blank" rel="noopener" aria-label={`Run on Compiler Explorer: ${title}`}>
-    <span class="ce-cta__play" aria-hidden="true">▸</span>
-    <span class="ce-cta__main">
-      <span class="ce-cta__eyebrow">Run on Compiler Explorer</span>
-      <span class="ce-cta__title">{title}</span>
-      <span class="ce-cta__sub">{subtitle}</span>
-    </span>
-    <span class="ce-cta__arrow" aria-hidden="true">↗</span>
-  </a>
+  <div class="ce-cta-group">
+    <a class="ce-cta" href={href} target="_blank" rel="noopener" aria-label={`Run on Compiler Explorer (clang-p2996): ${title}`}>
+      <span class="ce-cta__play" aria-hidden="true">▸</span>
+      <span class="ce-cta__main">
+        <span class="ce-cta__eyebrow">Run on Compiler Explorer</span>
+        <span class="ce-cta__title">{title}</span>
+        <span class="ce-cta__sub">{subtitle}</span>
+      </span>
+      <span class="ce-cta__arrow" aria-hidden="true">↗</span>
+    </a>
+    {gccHref && (
+      <a class="ce-cta ce-cta--secondary" href={gccHref} target="_blank" rel="noopener" aria-label={`Also run on GCC 16.1: ${title}`}>
+        <span class="ce-cta__play" aria-hidden="true">▸</span>
+        <span class="ce-cta__main">
+          <span class="ce-cta__eyebrow">Also on GCC 16.1</span>
+          <span class="ce-cta__title">{title}</span>
+          <span class="ce-cta__sub">{gcc_subtitle}</span>
+        </span>
+        <span class="ce-cta__arrow" aria-hidden="true">↗</span>
+      </a>
+    )}
+  </div>
 )}
+
+<style>
+  .ce-cta-group { display: flex; flex-direction: column; gap: 0.5rem; margin: 1.5rem 0; }
+  .ce-cta-group .ce-cta { margin: 0; }
+  .ce-cta--secondary { border-left-color: var(--blue-deep) !important; }
+  .ce-cta--secondary:hover { border-color: var(--blue-deep) !important; }
+  .ce-cta--secondary .ce-cta__play { background: var(--blue-deep); }
+  .ce-cta--secondary:hover .ce-cta__play { background: var(--blue); }
+  .ce-cta--secondary .ce-cta__eyebrow { color: var(--blue-deep); }
+  .ce-cta--secondary:hover .ce-cta__arrow { color: var(--blue-deep); }
+</style>

--- a/src/content/posts/2026-04-26-why-cpp26-reflection-matters.mdx
+++ b/src/content/posts/2026-04-26-why-cpp26-reflection-matters.mdx
@@ -90,7 +90,7 @@ The gap isn't about performance. C++ has always been fast. It's about **ergonomi
 
 C++ has been trying to close this gap for almost twenty years. [N1958 (2006)](https://open-std.org/JTC1/SC22/WG21/docs/papers/2006/n1958.pdf) proposed reflection. N3956 (2014), N4428 (2015), P0194 (2016), the Reflection TS (2019), and P1240 "Scalable Reflection" (2020) all came and went. The committee couldn't agree on API shape: reflections as types or as values? runtime or compile-time? how do they compose with concepts and templates? should there be a separate meta-language? Each proposal had merit; each stalled on a different detail.
 
-After seven major proposals and most of two decades, [P2996 "Reflection for C++26"](https://wg21.link/P2996) (Daveed Vandevoorde, Dan Katz, Barry Revzin, Faisal Vali) converged — value-based, compile-time, splicer-driven, and implementable. Adopted into C++26. Shipping in compilers now.
+After seven major proposals and most of two decades, [P2996 "Reflection for C++26"](https://wg21.link/P2996) (Daveed Vandevoorde, Dan Katz, Barry Revzin, Faisal Vali) converged — value-based, compile-time, splicer-driven, and implementable. Adopted into C++26. Shipping in compilers now: the [Bloomberg/clang-p2996 fork](https://github.com/bloomberg/clang-p2996) this series uses as its reference, and as of April 2026 [GCC 16.1](https://gcc.gnu.org/gcc-16/changes.html#cxx) (released, hosted on Compiler Explorer as `g161`).
 
 ## Act 3 — The answer
 
@@ -208,7 +208,7 @@ Reflection isn't just a feature. It's an inflection point:
 
 - **C++ closes one of its most-cited gaps with modern languages.** "You can't even walk over a struct's fields" stops landing.
 
-None of this is automatic. P2996 is new. The implementations are experimental — the [Bloomberg/clang-p2996 fork](https://github.com/bloomberg/clang-p2996) this series uses explicitly warns against production use. The library ecosystem will take years to catch up. Early adopters will hit compiler bugs, API shifts, and patterns that turn out to be wrong. But the shape of what's possible has changed, and it won't change back.
+None of this is automatic. P2996 is new. The implementations are experimental — the [Bloomberg/clang-p2996 fork](https://github.com/bloomberg/clang-p2996) this series uses explicitly warns against production use. GCC 16.1 ships P2996 in its April 2026 release, but the two implementations don't yet agree on every API surface (e.g. clang's `std::meta::annotation_of_type` vs GCC's `annotations_of_with_type`, plus differences in `consteval` strictness). A dedicated post later in the series compares the two; for now treat the toolchain as still-shifting. The library ecosystem will take years to catch up. Early adopters will hit compiler bugs, API shifts, and patterns that turn out to be wrong. But the shape of what's possible has changed, and it won't change back.
 
 ## Try it
 

--- a/src/content/posts/2026-04-29-first-reflection.mdx
+++ b/src/content/posts/2026-04-29-first-reflection.mdx
@@ -28,7 +28,7 @@ Everything reflection-related lives in one header:
 #include <experimental/meta>
 ```
 
-In clang-p2996 this also exists as plain `<meta>`. Both work; stick with `experimental` while the feature is, well, experimental.
+In clang-p2996 this also exists as plain `<meta>`. Both work; stick with `experimental` while the feature is, well, experimental. (GCC 16.1 ships only `<meta>` -- the `experimental` alias is a clang-p2996 thing. The Compiler Explorer link below has both buttons: clang-p2996 runs the source as-is, GCC 16.1 runs the same source with a one-line include rewrite.)
 
 ## The reflect operator
 
@@ -119,7 +119,7 @@ y: int
 
 Twelve meaningful lines. No macros, no external tool, no `#define BOOST_...`.
 
-<GodboltEmbed id="bq9WjeeM5" title="Your first ^^ — walking Point's members" />
+<GodboltEmbed id="bq9WjeeM5" gcc_id="n86cE3aWq" title="Your first ^^ — walking Point's members" />
 
 ## The primitives you just used
 

--- a/src/data/godbolt-permalinks.yml
+++ b/src/data/godbolt-permalinks.yml
@@ -53,6 +53,24 @@ first-reflection:
       name: basic_string<char, char_traits<char>, allocator<char>>
 
       '
+    gcc_id: n86cE3aWq
+    gcc_url: https://godbolt.org/z/n86cE3aWq
+    gcc_expected_output: 'Point:
+
+      x: int
+
+      y: int
+
+
+      Line:
+
+      a: Point
+
+      b: Point
+
+      name: std::__cxx11::basic_string<char>
+
+      '
 splicing:
   splice_basics:
     id: TnMx1Ys5b


### PR DESCRIPTION
## Summary

GCC 16.1 ships C++26 reflection (P2996 + P3394 + P3096 + P3560 + P1306) as of its April 2026 release; on Compiler Explorer as \`g161\`. This PR responds in three commits:

1. **scripts/shorten-examples.py** -- gain a per-toolchain profile system (\`--compiler {clang,gcc,both}\`, default \`both\`). GCC profile rewrites \`<experimental/meta>\` -> \`<meta>\` on the wire; the .cpp on disk stays clang-shaped. Each profile is gated through the same compile + execute API verification before its shortlink is created.
2. **GodboltEmbed.astro** -- optional \`gcc_id\` + \`gcc_subtitle\` props. When set, renders a stacked group of two buttons (orange clang on top, blue GCC below). When unset, behaviour is unchanged.
3. **Posts 1 + 2** -- honest footnotes about the two-toolchain story. Post 2's GodboltEmbed gains \`gcc_id="n86cE3aWq"\`.

## Reality check

GCC 16.1's P2996 implementation has API + semantic differences from clang-p2996:
- \`std::meta::annotation_of_type\` (clang) vs \`annotations_of_with_type\` (GCC).
- Stricter consteval rules around member access via reflection.
- Only \`<meta>\` (no \`<experimental/meta>\` alias).

Of the four shipped/queued posts, only **post 2's describe.cpp** survives unchanged on GCC. Posts 1, 3, 4 stay clang-only for now (the script aborts on those, leaving their YAML untouched). A dedicated comparison post slots later in the series (planned around post 12).

## What this PR does NOT do

- No mass-rewrite of .cpp sources for GCC compatibility (the local container build is the source of truth; rewrites happen on the wire only).
- No Buffer-post recreation. Today's post-3 captions don't claim "clang only" and Sunday's post-4 captions are syntax-focused. No retraction needed.
- No new dedicated GCC-comparison post (Phase B, deferred until ~post 12).

## Verification

- \`NODE_ENV=production npm run build\`: 94 pages clean.
- \`grep -c "n86cE3aWq" dist/posts/first-reflection/index.html\` -> 1 (GCC button rendered).
- \`grep -c "GCC 16.1" dist/posts/why-cpp26-reflection-matters/index.html\` -> 2 (both footnotes rendered).
- Live godbolt round-trip via API on the new GCC link returns compile.code=0, exec.code=0 with 85 chars stdout matching the captured \`gcc_expected_output\`.

## Cron guards

The pre-Buffer guards (\`cfa5762d\` for post 3, \`23614c0e\` for post 4) re-verify both clang AND GCC links automatically once this PR merges -- they invoke \`shorten-examples.py\` per slug, which now does the dual-profile check. Any GCC drift between now and pubDate will surface 15 min before each Buffer fire.

## Open follow-up

A dedicated short post "GCC 16 ships P2996 -- two compilers, one standard" slots after post 12 (clap-for-cpp), with side-by-side compile demos and the API-drift catalog. Will need a cadence cascade for posts 13-25 (each pushed by 2 days). Defer until posts 5-11 ship.