### PR TITLE
feat: GCC 16.1 compatibility audit -- matrix + auto-wired badges

### DIFF
--- a/docs/gcc-16-1-compatibility.md
+++ b/docs/gcc-16-1-compatibility.md
@@ -1,0 +1,260 @@
+# GCC 16.1 compatibility matrix
+
+_Generated 2026-05-01 by `scripts/gcc-compatibility-report.py`._
+
+Compiler: GCC 16.1 on Compiler Explorer (id `g161`), released April 2026.
+Flags: `-std=c++26 -freflection`
+
+## Source rewrites applied
+
+The .cpp on disk targets clang-p2996 (uses `<experimental/meta>`); the
+audit applies these rewrites in-memory before sending to GCC:
+
+- `<experimental/meta>` -> `<meta>`
+
+## Summary
+
+**15 / 28 OK; 1 output-drift; 12 compile-fail; 0 exec-fail**
+
+## Per-example matrix
+
+| # | Slug | Variant | Status | Category | Notes |
+|---|------|---------|--------|----------|-------|
+| 1 | `why-cpp26-reflection-matters` | `teaser` | OK | ok | matches clang stdout |
+| 1 | `why-cpp26-reflection-matters` | `teaser_annotated` | COMPILE_FAIL | api-name-diff | 'annotation_of_type' is not a member of 'std::meta'; did you mean 'annotations_of_with_type'? [-Wtem |
+| 1 | `why-cpp26-reflection-matters` | `teaser_formats` | COMPILE_FAIL | api-name-diff | 'annotation_of_type' is not a member of 'std::meta'; did you mean 'annotations_of_with_type'? [-Wtem |
+| 1 | `why-cpp26-reflection-matters` | `teaser_peel` | OK | ok | matches clang stdout |
+| 2 | `first-reflection` | `describe` | OUTPUT_DRIFT | runtime-diff | clang first line: 'Point:'; gcc: 'Point:' |
+| 3 | `splicing` | `splice_basics` | COMPILE_FAIL | consteval-strict | 'members' is not a constant expression |
+| 4 | `template-for-expansion-statements` | `dump` | COMPILE_FAIL | consteval-strict | modification of '<anonymous>' from outside current evaluation is not a constant expression |
+| 5 | `enum-to-string` | `renum` | OK | ok | ran cleanly (no clang baseline) |
+| 6 | `auto-formatter` | `formatter` | OK | ok | ran cleanly (no clang baseline) |
+| 7 | `derive-eq-hash` | `hash_demo` | OK | ok | ran cleanly (no clang baseline) |
+| 8 | `json-naive` | `rjson` | OK | ok | ran cleanly (no clang baseline) |
+| 9 | `annotations` | `annotated` | COMPILE_FAIL | api-name-diff | 'annotation_of_type' is not a member of 'std::meta'; did you mean 'annotations_of_with_type'? [-Wtem |
+| 10 | `json-deserialize` | `from_values` | OK | ok | ran cleanly (no clang baseline) |
+| 11 | `one-codegen-many-formats` | `formats_demo` | COMPILE_FAIL | api-name-diff | 'annotation_of_type' is not a member of 'std::meta'; did you mean 'annotations_of_with_type'? [-Wtem |
+| 12 | `clap-for-cpp` | `cli_demo` | COMPILE_FAIL | api-name-diff | 'annotation_of_type' is not a member of 'std::meta'; did you mean 'annotations_of_with_type'? [-Wtem |
+| 13 | `tiny-orm` | `sql_gen` | COMPILE_FAIL | api-name-diff | 'annotation_of_type' is not a member of 'std::meta'; did you mean 'annotations_of_with_type'? [-Wtem |
+| 14 | `dependency-injection` | `di_demo` | OK | ok | ran cleanly (no clang baseline) |
+| 15 | `auto-mocks` | `mock_demo` | OK | ok | ran cleanly (no clang baseline) |
+| 16 | `define-aggregate` | `pick` | OK | ok | ran cleanly (no clang baseline) |
+| 17 | `qt-moc-replacement` | `properties` | COMPILE_FAIL | api-name-diff | 'annotation_of_type' is not a member of 'std::meta'; did you mean 'annotations_of_with_type'? [-Wtem |
+| 18 | `cross-language-comparison` | `main` | OK | ok | ran cleanly (no clang baseline) |
+| 19 | `reflect-llmschema` | `llmschema` | COMPILE_FAIL | api-name-diff | 'annotation_of_type' is not a member of 'std::meta'; did you mean 'annotations_of_with_type'? [-Wtem |
+| 20 | `reflect-arbitrary` | `arbitrary` | OK | ok | ran cleanly (no clang baseline) |
+| 21 | `reflect-optics` | `optics` | OK | ok | ran cleanly (no clang baseline) |
+| 22 | `reflect-dx` | `natvis_emit` | OK | ok | ran cleanly (no clang baseline) |
+| 23 | `reflect-telemetry` | `prometheus_emit` | COMPILE_FAIL | api-name-diff | 'annotation_of_type' is not a member of 'std::meta'; did you mean 'annotations_of_with_type'? [-Wtem |
+| 24 | `reflect-tracing` | `trace_emit` | COMPILE_FAIL | api-name-diff | no matching function for call to 'define_static_string(const char*)' |
+| 25 | `reflect-soa` | `soa` | OK | ok | ran cleanly (no clang baseline) |
+
+## Failure detail
+
+### 01 `why-cpp26-reflection-matters` / `teaser_annotated` -- COMPILE_FAIL
+
+Category: **api-name-diff**
+
+```
+<source>: In function 'consteval std::string_view rjson::key_of()':
+<source>:72:49: error: 'annotation_of_type' is not a member of 'std::meta'; did you mean 'annotations_of_with_type'? [-Wtemplate-body]
+   72 |     if constexpr (constexpr auto a = std::meta::annotation_of_type<json_name_tag>(Member)) {
+      |                                                 ^~~~~~~~~~~~~~~~~~
+      |              
+```
+
+### 01 `why-cpp26-reflection-matters` / `teaser_formats` -- COMPILE_FAIL
+
+Category: **api-name-diff**
+
+```
+<source>: In function 'consteval std::string_view rserial::key_of()':
+<source>:57:32: error: 'annotation_of_type' is not a member of 'std::meta'; did you mean 'annotations_of_with_type'? [-Wtemplate-body]
+   57 |                   = std::meta::annotation_of_type<json_name_tag>(Member)) {
+      |                                ^~~~~~~~~~~~~~~~~~
+      |                                annotations_of
+```
+
+### 02 `first-reflection` / `describe` -- OUTPUT_DRIFT
+
+Category: **runtime-diff**
+
+```
+--- clang expected ---
+Point:
+x: int
+y: int
+
+Line:
+a: Point
+b: Point
+name: basic_string<char, char_traits<char>, allocator<char>>
+
+--- gcc actual ---
+Point:
+x: int
+y: int
+
+Line:
+a: Point
+b: Point
+name: std::__cxx11::basic_string<char>
+
+```
+
+### 03 `splicing` / `splice_basics` -- COMPILE_FAIL
+
+Category: **consteval-strict**
+
+```
+<source>: In instantiation of 'void dump(const T&) [with T = Point]':
+<source>:40:9:   required from here
+   40 |     dump(p);
+      |     ~~~~^~~
+<source>:29:38: error: 'members' is not a constant expression
+   29 |     template for (constexpr auto m : members) {
+      |                                      ^~~~~~~
+<source>:29:38: note: reference to 'members' is not a constant expression
+<source>
+```
+
+### 04 `template-for-expansion-statements` / `dump` -- COMPILE_FAIL
+
+Category: **consteval-strict**
+
+```
+<source>: In function 'int main()':
+<source>:32:5: error: modification of '<anonymous>' from outside current evaluation is not a constant expression
+   32 |     }
+      |     ^
+```
+
+### 09 `annotations` / `annotated` -- COMPILE_FAIL
+
+Category: **api-name-diff**
+
+```
+<source>: In function 'consteval std::string_view rjson::key_of()':
+<source>:51:49: error: 'annotation_of_type' is not a member of 'std::meta'; did you mean 'annotations_of_with_type'? [-Wtemplate-body]
+   51 |     if constexpr (constexpr auto a = std::meta::annotation_of_type<json_name_tag>(Member)) {
+      |                                                 ^~~~~~~~~~~~~~~~~~
+      |              
+```
+
+### 11 `one-codegen-many-formats` / `formats_demo` -- COMPILE_FAIL
+
+Category: **api-name-diff**
+
+```
+<source>: In function 'consteval std::string_view rserial::key_of()':
+<source>:57:32: error: 'annotation_of_type' is not a member of 'std::meta'; did you mean 'annotations_of_with_type'? [-Wtemplate-body]
+   57 |                   = std::meta::annotation_of_type<json_name_tag>(Member)) {
+      |                                ^~~~~~~~~~~~~~~~~~
+      |                                annotations_of
+```
+
+### 12 `clap-for-cpp` / `cli_demo` -- COMPILE_FAIL
+
+Category: **api-name-diff**
+
+```
+<source>: In function 'Args cli::parse(std::span<const std::basic_string_view<char> >)':
+<source>:42:39: error: 'annotation_of_type' is not a member of 'std::meta'; did you mean 'annotations_of_with_type'? [-Wtemplate-body]
+   42 |             if constexpr (!std::meta::annotation_of_type<positional>(m).has_value()) {
+      |                                       ^~~~~~~~~~~~~~~~~~
+      |         
+```
+
+### 13 `tiny-orm` / `sql_gen` -- COMPILE_FAIL
+
+Category: **api-name-diff**
+
+```
+<source>: In function 'consteval const char* orm::table_name_of()':
+<source>:42:49: error: 'annotation_of_type' is not a member of 'std::meta'; did you mean 'annotations_of_with_type'? [-Wtemplate-body]
+   42 |     if constexpr (constexpr auto a = std::meta::annotation_of_type<table_tag>(^^T))
+      |                                                 ^~~~~~~~~~~~~~~~~~
+      |                       
+```
+
+### 17 `qt-moc-replacement` / `properties` -- COMPILE_FAIL
+
+Category: **api-name-diff**
+
+```
+<source>: In function 'std::vector<rqt::property_info> rqt::properties_of()':
+<source>:37:34: error: 'annotation_of_type' is not a member of 'std::meta'; did you mean 'annotations_of_with_type'? [-Wtemplate-body]
+   37 |         if constexpr (std::meta::annotation_of_type<property>(m).has_value()) {
+      |                                  ^~~~~~~~~~~~~~~~~~
+      |                                
+```
+
+### 19 `reflect-llmschema` / `llmschema` -- COMPILE_FAIL
+
+Category: **api-name-diff**
+
+```
+<source>: In function 'consteval const char* llm::openai_tool_json(std::string_view)':
+<source>:73:32: error: 'annotation_of_type' is not a member of 'std::meta'; did you mean 'annotations_of_with_type'? [-Wtemplate-body]
+   73 |                   = std::meta::annotation_of_type<description_tag>(^^ArgsStruct)) {
+      |                                ^~~~~~~~~~~~~~~~~~
+      |                     
+```
+
+### 23 `reflect-telemetry` / `prometheus_emit` -- COMPILE_FAIL
+
+Category: **api-name-diff**
+
+```
+<source>: In function 'std::string metrics::expose_prometheus(const T&)':
+<source>:38:41: error: 'annotation_of_type' is not a member of 'std::meta'; did you mean 'annotations_of_with_type'? [-Wtemplate-body]
+   38 |     constexpr auto type_ns = std::meta::annotation_of_type<namespace_tag>(^^T);
+      |                                         ^~~~~~~~~~~~~~~~~~
+      |                             
+```
+
+### 24 `reflect-tracing` / `trace_emit` -- COMPILE_FAIL
+
+Category: **api-name-diff**
+
+```
+<source>: In function 'void with_nttp_named()':
+<source>:209:65: error: no matching function for call to 'define_static_string(const char*)'
+  209 |     static constexpr char const* _fn = std::define_static_string(
+      |                                        ~~~~~~~~~~~~~~~~~~~~~~~~~^
+  210 |         std::source_location::current().function_name());
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+## Compiler-support footer
+
+Posts confirmed to run on **clang-p2996 + GCC 16.1**:
+
+- `auto-formatter`
+- `auto-mocks`
+- `cross-language-comparison`
+- `define-aggregate`
+- `dependency-injection`
+- `derive-eq-hash`
+- `enum-to-string`
+- `first-reflection`
+- `json-deserialize`
+- `json-naive`
+- `reflect-arbitrary`
+- `reflect-dx`
+- `reflect-optics`
+- `reflect-soa`
+
+Posts that currently ship as **clang-p2996 only**:
+
+- `annotations`
+- `clap-for-cpp`
+- `one-codegen-many-formats`
+- `qt-moc-replacement`
+- `reflect-llmschema`
+- `reflect-telemetry`
+- `reflect-tracing`
+- `splicing`
+- `template-for-expansion-statements`
+- `tiny-orm`
+- `why-cpp26-reflection-matters`

--- a/scripts/gcc-compatibility-report.py
+++ b/scripts/gcc-compatibility-report.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""
+GCC 16.1 compatibility audit for the wro.cpp C++26 reflection series.
+
+Walks every `posts/<NN>-<slug>/examples/*.cpp` in the cpp26 examples repo,
+applies the GCC source rewrites from `COMPILER_PROFILES["gcc"]` in
+scripts/shorten-examples.py, and POSTs to godbolt.org's compile API for
+g161 with `-std=c++26 -freflection` and `filters.execute=true`.
+
+For each example, classify against the existing clang `expected_output`
+captured in src/data/godbolt-permalinks.yml:
+
+  OK              -- compile + exec OK; stdout matches clang's expected output
+  OUTPUT_DRIFT    -- compile + exec OK but stdout differs from clang's
+  EXEC_FAIL       -- compile OK; program exit != 0
+  COMPILE_FAIL    -- compile.code != 0
+  NETWORK_ERR     -- HTTP / timeout error (one retry)
+
+Outputs:
+  docs/gcc-16-1-compatibility.md   -- full matrix + per-failure stderr
+  src/data/godbolt-permalinks.yml  -- gcc_id / gcc_url / gcc_expected_output
+                                      populated for OK + OUTPUT_DRIFT (idempotent)
+
+Run:
+    scripts/gcc-compatibility-report.py
+    scripts/gcc-compatibility-report.py --dry-run     # no YAML / md write
+    scripts/gcc-compatibility-report.py --no-shorten  # md only
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
+
+
+def strip_ansi(s: str) -> str:
+    return ANSI_RE.sub("", s)
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("error: PyYAML not installed. run: pip3 install pyyaml")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+# Reuse helpers + profiles from the existing shortener script so the
+# rewrite list and compile profile stay in one place.
+import importlib.util  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "shorten_examples", REPO_ROOT / "scripts" / "shorten-examples.py"
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+COMPILER_PROFILES = _mod.COMPILER_PROFILES
+apply_rewrites = _mod.apply_rewrites
+compile_and_run = _mod.compile_and_run
+shorten = _mod.shorten
+
+YAML_PATH = REPO_ROOT / "src" / "data" / "godbolt-permalinks.yml"
+DOC_PATH = REPO_ROOT / "docs" / "gcc-16-1-compatibility.md"
+CPP26_ROOT = Path("/Users/filipsajdak/dev/c++26")
+
+# Folder NN-slug -> mdx slug (which is the YAML key).
+SLUG_MAP = {
+    "01-why-it-matters": "why-cpp26-reflection-matters",
+    "02-first-reflection": "first-reflection",
+    "03-splicing": "splicing",
+    "04-expansion-statements": "template-for-expansion-statements",
+    "05-enum-to-string": "enum-to-string",
+    "06-auto-formatter": "auto-formatter",
+    "07-derive-eq-hash": "derive-eq-hash",
+    "08-json-naive": "json-naive",
+    "09-annotations": "annotations",
+    "10-json-deserialize": "json-deserialize",
+    "11-json-schema-yaml-toml": "one-codegen-many-formats",
+    "12-clap-for-cpp": "clap-for-cpp",
+    "13-tiny-orm": "tiny-orm",
+    "14-dependency-injection": "dependency-injection",
+    "15-auto-mocks": "auto-mocks",
+    "16-define-aggregate": "define-aggregate",
+    "17-qt-moc-replacement": "qt-moc-replacement",
+    "18-cross-language-comparison": "cross-language-comparison",
+    "19-reflect-llmschema": "reflect-llmschema",
+    "20-reflect-arbitrary": "reflect-arbitrary",
+    "21-reflect-optics": "reflect-optics",
+    "22-reflect-dx": "reflect-dx",
+    "23-reflect-telemetry": "reflect-telemetry",
+    "24-reflect-tracing": "reflect-tracing",
+    "25-reflect-soa": "reflect-soa",
+}
+
+
+def compile_url(profile: dict) -> str:
+    return f"https://godbolt.org/api/compiler/{profile['id']}/compile"
+
+
+def compile_and_run_with_retry(source: str, profile: dict) -> dict:
+    """Single-pass compile+execute against godbolt; retries once on
+    network error. Returns a structured dict with raw fields so the
+    caller can classify (compile_fail vs exec_fail vs ok).
+    """
+    payload = {
+        "source": source,
+        "options": {
+            "userArguments": profile["options"],
+            "filters": {"execute": True},
+        },
+    }
+    last_err = None
+    for attempt in (1, 2):
+        req = urllib.request.Request(
+            compile_url(profile),
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                body = json.loads(resp.read().decode("utf-8"))
+            compile_code = body.get("code", -1)
+            compile_stderr = strip_ansi("\n".join(
+                x.get("text", "") for x in body.get("stderr", [])
+            ))
+            exec_result = body.get("execResult") or {}
+            exec_code = exec_result.get("code")
+            exec_stdout = "\n".join(
+                x.get("text", "") for x in exec_result.get("stdout", [])
+            )
+            exec_stderr = strip_ansi("\n".join(
+                x.get("text", "") for x in exec_result.get("stderr", [])
+            ))
+            return {
+                "network_ok": True,
+                "compile_code": compile_code,
+                "compile_stderr": compile_stderr,
+                "exec_code": exec_code,
+                "exec_stdout": exec_stdout,
+                "exec_stderr": exec_stderr,
+            }
+        except (urllib.error.URLError, TimeoutError, ConnectionError) as e:
+            last_err = e
+            if attempt == 1:
+                time.sleep(2)
+                continue
+    return {
+        "network_ok": False,
+        "error": f"{type(last_err).__name__}: {last_err}",
+    }
+
+
+def load_yaml() -> dict:
+    if not YAML_PATH.exists():
+        return {}
+    with YAML_PATH.open() as f:
+        return yaml.safe_load(f) or {}
+
+
+def write_yaml(data: dict) -> None:
+    header = []
+    for line in YAML_PATH.read_text().splitlines(keepends=True):
+        if line.startswith("#") or line.strip() == "":
+            header.append(line)
+        else:
+            break
+    body = yaml.safe_dump(data, sort_keys=False, allow_unicode=False, width=120)
+    YAML_PATH.write_text("".join(header) + body)
+
+
+def classify(result: dict, expected_output: str | None) -> tuple[str, str]:
+    """Return (status, category). Category is a one-word bucket used for
+    the at-a-glance column: ok / api-name-diff / consteval-strict /
+    missing-feature / runtime-diff / unknown.
+    """
+    if not result["network_ok"]:
+        return "NETWORK_ERR", "unknown"
+    if result["compile_code"] != 0:
+        stderr = result["compile_stderr"].lower()
+        if (
+            "no member named" in stderr
+            or "no template named" in stderr
+            or "has not been declared" in stderr
+            or "is not a member of" in stderr
+            or "no matching function for call" in stderr
+        ):
+            cat = "api-name-diff"
+        elif "not a constant expression" in stderr or "is not constexpr" in stderr or "consteval" in stderr or "non-constant condition" in stderr:
+            cat = "consteval-strict"
+        elif "expansion-statement" in stderr or "template for" in stderr or "define_aggregate" in stderr or "annotations_of" in stderr or "data_member_spec" in stderr:
+            cat = "missing-feature"
+        else:
+            cat = "unknown"
+        return "COMPILE_FAIL", cat
+    if result["exec_code"] not in (0, None):
+        return "EXEC_FAIL", "runtime-diff"
+    if expected_output is not None and result["exec_stdout"].strip() != expected_output.strip():
+        return "OUTPUT_DRIFT", "runtime-diff"
+    return "OK", "ok"
+
+
+def render_md(rows: list[dict], gcc_options: str, rewrites: list[tuple[str, str]]) -> str:
+    counts = {"OK": 0, "OUTPUT_DRIFT": 0, "COMPILE_FAIL": 0, "EXEC_FAIL": 0, "NETWORK_ERR": 0}
+    for r in rows:
+        counts[r["status"]] = counts.get(r["status"], 0) + 1
+    total = len(rows)
+
+    rewrite_lines = "\n".join(f"- `{a}` -> `{b}`" for a, b in rewrites) or "- (none)"
+
+    lines = [
+        "# GCC 16.1 compatibility matrix",
+        "",
+        f"_Generated 2026-05-01 by `scripts/gcc-compatibility-report.py`._",
+        "",
+        "Compiler: GCC 16.1 on Compiler Explorer (id `g161`), released April 2026.",
+        f"Flags: `{gcc_options}`",
+        "",
+        "## Source rewrites applied",
+        "",
+        "The .cpp on disk targets clang-p2996 (uses `<experimental/meta>`); the",
+        "audit applies these rewrites in-memory before sending to GCC:",
+        "",
+        rewrite_lines,
+        "",
+        "## Summary",
+        "",
+        f"**{counts['OK']} / {total} OK; {counts['OUTPUT_DRIFT']} output-drift; "
+        f"{counts['COMPILE_FAIL']} compile-fail; {counts['EXEC_FAIL']} exec-fail"
+        + (f"; {counts['NETWORK_ERR']} network-err" if counts.get('NETWORK_ERR') else "")
+        + "**",
+        "",
+        "## Per-example matrix",
+        "",
+        "| # | Slug | Variant | Status | Category | Notes |",
+        "|---|------|---------|--------|----------|-------|",
+    ]
+    for r in rows:
+        notes = r["notes"].replace("|", "\\|").replace("\n", " ")[:120]
+        lines.append(
+            f"| {r['nn']} | `{r['slug']}` | `{r['variant']}` | "
+            f"{r['status']} | {r['category']} | {notes} |"
+        )
+
+    failure_rows = [r for r in rows if r["status"] not in ("OK",)]
+    if failure_rows:
+        lines += ["", "## Failure detail", ""]
+        for r in failure_rows:
+            lines += [
+                f"### {r['nn']:02d} `{r['slug']}` / `{r['variant']}` -- {r['status']}",
+                "",
+                f"Category: **{r['category']}**",
+                "",
+                "```",
+                r["detail"][:400] or "(no stderr captured)",
+                "```",
+                "",
+            ]
+
+    # Footer: which posts ship with both badges vs clang-only.
+    by_slug: dict[str, list[dict]] = {}
+    for r in rows:
+        by_slug.setdefault(r["slug"], []).append(r)
+    both, clang_only = [], []
+    for slug, group in by_slug.items():
+        if all(g["status"] in ("OK", "OUTPUT_DRIFT") for g in group):
+            both.append(slug)
+        else:
+            clang_only.append(slug)
+
+    lines += [
+        "## Compiler-support footer",
+        "",
+        "Posts confirmed to run on **clang-p2996 + GCC 16.1**:",
+        "",
+    ]
+    lines += [f"- `{s}`" for s in sorted(both)] or ["- (none)"]
+    lines += [
+        "",
+        "Posts that currently ship as **clang-p2996 only**:",
+        "",
+    ]
+    lines += [f"- `{s}`" for s in sorted(clang_only)] or ["- (none)"]
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dry-run", action="store_true",
+                   help="don't write the .md or YAML")
+    p.add_argument("--no-shorten", action="store_true",
+                   help="skip godbolt /api/shortener calls (write only the .md)")
+    args = p.parse_args()
+
+    profile = COMPILER_PROFILES["gcc"]
+    yaml_data = load_yaml()
+    rows: list[dict] = []
+    yaml_changed = False
+
+    folders = sorted(SLUG_MAP.keys())
+    for nn_slug in folders:
+        slug = SLUG_MAP[nn_slug]
+        nn = int(nn_slug.split("-", 1)[0])
+        examples_dir = CPP26_ROOT / "posts" / nn_slug / "examples"
+        if not examples_dir.is_dir():
+            print(f"warn: missing {examples_dir}", file=sys.stderr)
+            continue
+        sources = sorted(examples_dir.glob("*.cpp"))
+        for src in sources:
+            variant = src.stem
+            label = f"{nn:02d} {slug}.{variant}"
+            print(f"audit  {label} ...", flush=True)
+            source_text = src.read_text()
+            rewritten = apply_rewrites(source_text, profile)
+
+            existing = (yaml_data.get(slug) or {}).get(variant) or {}
+            expected = existing.get("expected_output")
+
+            result = compile_and_run_with_retry(rewritten, profile)
+            status, category = classify(result, expected)
+
+            notes = ""
+            detail = ""
+            if status == "COMPILE_FAIL":
+                detail = result["compile_stderr"]
+                # Prefer the first line containing 'error:' for the table cell.
+                err_line = next(
+                    (ln for ln in detail.splitlines() if "error:" in ln),
+                    (detail.splitlines() or [""])[0],
+                )
+                # Strip the leading "<source>:NN:CC: error: " prefix for brevity.
+                err_msg = re.sub(r"^.*?error:\s*", "", err_line)
+                notes = err_msg[:100]
+            elif status == "EXEC_FAIL":
+                detail = result["exec_stderr"] or f"exit code {result['exec_code']}"
+                notes = f"exec exit {result['exec_code']}"
+            elif status == "OUTPUT_DRIFT":
+                clang_one = (expected or "").splitlines()[0] if expected else ""
+                gcc_one = (result["exec_stdout"] or "").splitlines()[0]
+                notes = f"clang first line: {clang_one[:40]!r}; gcc: {gcc_one[:40]!r}"
+                detail = (
+                    f"--- clang expected ---\n{expected}\n"
+                    f"--- gcc actual ---\n{result['exec_stdout']}"
+                )
+            elif status == "NETWORK_ERR":
+                detail = result.get("error", "")
+                notes = detail[:80]
+            elif status == "OK":
+                notes = "matches clang stdout" if expected else "ran cleanly (no clang baseline)"
+
+            print(f"       -> {status} ({category})")
+            rows.append({
+                "nn": nn,
+                "slug": slug,
+                "variant": variant,
+                "status": status,
+                "category": category,
+                "notes": notes,
+                "detail": detail,
+            })
+
+            # YAML population for OK / OUTPUT_DRIFT (ran cleanly on g161).
+            if status in ("OK", "OUTPUT_DRIFT") and not args.no_shorten:
+                yaml_data.setdefault(slug, {})
+                entry = dict(yaml_data[slug].get(variant) or {})
+                if entry.get("gcc_id"):
+                    pass  # idempotent: already shortened
+                else:
+                    title = entry.get("title") or variant.replace("_", " ").capitalize()
+                    try:
+                        result_short = shorten(rewritten, title, profile)
+                        entry.setdefault("title", title)
+                        entry["gcc_id"] = result_short["id"]
+                        entry["gcc_url"] = result_short["url"]
+                        entry["gcc_expected_output"] = result["exec_stdout"]
+                        yaml_data[slug][variant] = entry
+                        yaml_changed = True
+                        print(f"       shortened -> {result_short['url']}")
+                    except Exception as e:
+                        print(f"       shorten FAILED: {e}", file=sys.stderr)
+
+    md = render_md(rows, profile["options"], profile["source_rewrites"])
+    if args.dry_run:
+        print("\n--- DRY RUN: matrix would be ---\n")
+        print(md)
+        return 0
+
+    DOC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    DOC_PATH.write_text(md)
+    print(f"\nwrote {DOC_PATH.relative_to(REPO_ROOT)}")
+
+    if yaml_changed:
+        write_yaml(yaml_data)
+        print(f"wrote {YAML_PATH.relative_to(REPO_ROOT)}")
+    else:
+        print("YAML unchanged")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/components/GodboltEmbed.astro
+++ b/src/components/GodboltEmbed.astro
@@ -42,6 +42,14 @@ const {
 const isPlaceholder = id.startsWith('TODO') || id === 'placeholder';
 const href = `https://godbolt.org/z/${id}`;
 const gccHref = gcc_id ? `https://godbolt.org/z/${gcc_id}` : null;
+// Compiler-support badge: only meaningful for real (non-placeholder) ids.
+// "+ GCC 16.1" when a gcc_id was wired; otherwise the example is currently
+// known to run on clang-p2996 only (per docs/gcc-16-1-compatibility.md).
+const badgeLabel = !isPlaceholder
+  ? gcc_id
+    ? 'Tested: clang-p2996 + GCC 16.1'
+    : 'Tested: clang-p2996 only'
+  : null;
 ---
 {isPlaceholder ? (
   <div class="ce-cta ce-cta--placeholder">
@@ -55,6 +63,11 @@ const gccHref = gcc_id ? `https://godbolt.org/z/${gcc_id}` : null;
   </div>
 ) : (
   <div class="ce-cta-group">
+    {badgeLabel && (
+      <div class="ce-compiler-badge" aria-label={badgeLabel}>
+        <span aria-hidden="true">&#9642;</span> {badgeLabel}
+      </div>
+    )}
     <a class="ce-cta" href={href} target="_blank" rel="noopener" aria-label={`Run on Compiler Explorer (clang-p2996): ${title}`}>
       <span class="ce-cta__play" aria-hidden="true">▸</span>
       <span class="ce-cta__main">
@@ -87,4 +100,12 @@ const gccHref = gcc_id ? `https://godbolt.org/z/${gcc_id}` : null;
   .ce-cta--secondary:hover .ce-cta__play { background: var(--blue); }
   .ce-cta--secondary .ce-cta__eyebrow { color: var(--blue-deep); }
   .ce-cta--secondary:hover .ce-cta__arrow { color: var(--blue-deep); }
+  .ce-compiler-badge {
+    font-size: 0.7rem;
+    font-style: italic;
+    color: var(--ink-faint);
+    line-height: 1;
+    margin: 0 0 0.1rem 0.1rem;
+    letter-spacing: 0.01em;
+  }
 </style>

--- a/src/components/TrackingHooks.astro
+++ b/src/components/TrackingHooks.astro
@@ -1,18 +1,23 @@
 ---
-/**
- * Client-side tracking hooks (outbound clicks + scroll depth).
- *
- * Renders one inline <script> that, after DOM ready:
- *   1. Attaches a click listener to every <a href> with an external host;
- *      fires `gtag('event', 'click_outbound', { href, host })` so each
- *      external destination shows up as its own event in GA4.
- *   2. Listens for scroll past 25/50/75/100% of document height and fires
- *      `gtag('event', 'scroll_depth', { percent })` once per threshold.
- *
- * Both events also fire when consent is 'denied' but Consent Mode v2
- * sends them as cookieless pings -- GA4 still gets aggregate signals.
- *
- * Includes nothing if PUBLIC_GA_ID is unset.
+/*
+   Client-side tracking hooks (outbound clicks + scroll depth).
+
+   Renders one inline script tag that, after the DOM is ready:
+     1. Attaches a click listener to every anchor with an external host
+        and fires gtag('event', 'click_outbound', { href, host }) so each
+        external destination shows up as its own event in GA4.
+     2. Listens for scroll past 25/50/75/100% of document height and fires
+        gtag('event', 'scroll_depth', { percent }) once per threshold.
+
+   Both events also fire when consent is 'denied' but Consent Mode v2
+   sends them as cookieless pings -- GA4 still gets aggregate signals.
+
+   Includes nothing if PUBLIC_GA_ID is unset.
+
+   Note: avoid JSDoc-style block comments here -- Astro's dev-mode
+   esbuild parser misreads literal HTML tags inside frontmatter JSDoc
+   and crashes with "Expected ';'" errors. Plain block comments
+   without nested comment-terminator sequences are safe.
  */
 const gaId = import.meta.env.PUBLIC_GA_ID;
 const siteHost = 'wrocpp.github.io';

--- a/src/content/posts/2026-04-26-why-cpp26-reflection-matters.mdx
+++ b/src/content/posts/2026-04-26-why-cpp26-reflection-matters.mdx
@@ -116,7 +116,7 @@ std::string to_json(T const& obj) {
 }
 ```
 
-<GodboltEmbed id="n4eK93vfv" title="40-line JSON serializer" />
+<GodboltEmbed id="n4eK93vfv" gcc_id="e3346Pxoh" title="40-line JSON serializer" />
 
 Five new things are happening:
 
@@ -186,7 +186,7 @@ Three things make this work, and it's worth naming each:
 
 After `-O2`, the codegen is effectively identical — the optimiser proves the `first` flag's value per unrolled iteration and elides the branches either way. The win isn't runtime cost; it's source-level intent. The peel version has zero branches in the source, handles empty structs explicitly via `if constexpr`, and reads like "first, then rest" instead of "carry a flag".
 
-<GodboltEmbed id="MzM4bh3rj" title="Peel-first variant — first iteration hoisted to compile time" />
+<GodboltEmbed id="MzM4bh3rj" gcc_id="439ro4sno" title="Peel-first variant — first iteration hoisted to compile time" />
 
 ---
 

--- a/src/data/godbolt-permalinks.yml
+++ b/src/data/godbolt-permalinks.yml
@@ -13,11 +13,17 @@ why-cpp26-reflection-matters:
     url: https://godbolt.org/z/n4eK93vfv
     title: 40-line JSON serializer with reflection
     expected_output: '{"name":"Filip","age":40,"admin":true,"home":{"city":"Warsaw","postal_code":12345}}'
+    gcc_id: e3346Pxoh
+    gcc_url: https://godbolt.org/z/e3346Pxoh
+    gcc_expected_output: '{"name":"Filip","age":40,"admin":true,"home":{"city":"Warsaw","postal_code":12345}}'
   teaser_peel:
     id: MzM4bh3rj
     url: https://godbolt.org/z/MzM4bh3rj
     title: "Peel-first variant \u2014 first iteration hoisted to compile time"
     expected_output: '{"name":"Filip","age":40,"admin":true,"home":{"city":"Warsaw","postal_code":12345}}'
+    gcc_id: 439ro4sno
+    gcc_url: https://godbolt.org/z/439ro4sno
+    gcc_expected_output: '{"name":"Filip","age":40,"admin":true,"home":{"city":"Warsaw","postal_code":12345}}'
   teaser_annotated:
     id: 97WdeKs7v
     url: https://godbolt.org/z/97WdeKs7v
@@ -83,3 +89,118 @@ template-for-expansion-statements:
     url: https://godbolt.org/z/j9vWKaEG6
     title: Dump
     expected_output: "Point:\n  x = 3\n  y = 4\ntuple element: 1\ntuple element: 2.5\ntuple element: c"
+enum-to-string:
+  renum:
+    title: Renum
+    gcc_id: cTKnshToM
+    gcc_url: https://godbolt.org/z/cTKnshToM
+    gcc_expected_output: 'green
+
+      read|exec'
+auto-formatter:
+  formatter:
+    title: Formatter
+    gcc_id: Y5ohxse9d
+    gcc_url: https://godbolt.org/z/Y5ohxse9d
+    gcc_expected_output: 'User{name: Filip, age: 40, admin: true, home: Address{city: Warsaw, postal_code: 12345}}'
+derive-eq-hash:
+  hash_demo:
+    title: Hash demo
+    gcc_id: Eada5fhx6
+    gcc_url: https://godbolt.org/z/Eada5fhx6
+    gcc_expected_output: '(3,4) -> 3-4-5
+
+      (0,0) -> origin
+
+      hash({0,0}) = 9332004819697274819
+
+      hash({3,4}) = 9332004819697328066'
+json-naive:
+  rjson:
+    title: Rjson
+    gcc_id: PnzTqMPbP
+    gcc_url: https://godbolt.org/z/PnzTqMPbP
+    gcc_expected_output: '{"name":"Filip","age":40,"admin":true,"home":{"city":"Warsaw","postal_code":12345},"aliases":["fsjdk","phi"]}'
+json-deserialize:
+  from_values:
+    title: From values
+    gcc_id: f5dvhjMdP
+    gcc_url: https://godbolt.org/z/f5dvhjMdP
+    gcc_expected_output: "name=Filip age=40 admin=true\nfailure path: at .age \u2014 expected number"
+dependency-injection:
+  di_demo:
+    title: Di demo
+    gcc_id: zqs9vn7vo
+    gcc_url: https://godbolt.org/z/zqs9vn7vo
+    gcc_expected_output: 'Hello @tick=1
+
+      Hello @tick=2'
+auto-mocks:
+  mock_demo:
+    title: Mock demo
+    gcc_id: qW9vYcTTj
+    gcc_url: https://godbolt.org/z/qW9vYcTTj
+    gcc_expected_output: 'now:  42
+
+      zone: Europe/Warsaw
+
+      now:  42
+
+      IClock::now called 2 times
+
+      IClock::zone called 1 times'
+define-aggregate:
+  pick:
+    title: Pick
+    gcc_id: xTxofns9E
+    gcc_url: https://godbolt.org/z/xTxofns9E
+    gcc_expected_output: "Pick<User, \"name\", \"age\", \"admin\"> would contain:\n  name : std::__cxx11::basic_string<char>\n\
+      \  age : int\n  admin : bool\n(Type synthesis via std::meta::define_aggregate is experimental;\n full Pick / Omit /\
+      \ Partial land once the compiler context relaxes.)"
+cross-language-comparison:
+  main:
+    title: Main
+    gcc_id: GYT781eY5
+    gcc_url: https://godbolt.org/z/GYT781eY5
+    gcc_expected_output: '{"name":"Filip","age":40,"admin":true}'
+reflect-arbitrary:
+  arbitrary:
+    title: Arbitrary
+    gcc_id: 8nEcd6zce
+    gcc_url: https://godbolt.org/z/8nEcd6zce
+    gcc_expected_output: 'Generated User #0: name=uy       age=18  admin=true home={city=ppel pc=15}
+
+      Generated User #1: name=b        age=46  admin=true home={city=pd pc=71}
+
+      Generated User #2: name=abzs     age=84  admin=true home={city=ae pc=100}
+
+      Generated User #3: name=q        age=30  admin=true home={city=ala pc=29}
+
+      Generated User #4: name=pkd      age=4   admin=false home={city=jglcu pc=62}'
+reflect-optics:
+  optics:
+    title: Optics
+    gcc_id: bsErWaTex
+    gcc_url: https://godbolt.org/z/bsErWaTex
+    gcc_expected_output: 'view: Wroclaw
+
+      set:  Warsaw
+
+      over: 50002'
+reflect-dx:
+  natvis_emit:
+    title: Natvis emit
+    gcc_id: s3GzrhjvM
+    gcc_url: https://godbolt.org/z/s3GzrhjvM
+    gcc_expected_output: "<Type Name=\"Address\">\n  <DisplayString>{city={city} postal_code={postal_code}}</DisplayString>\n\
+      \  <Expand>\n    <Item Name=\"city\">city</Item>\n    <Item Name=\"postal_code\">postal_code</Item>\n  </Expand>\n</Type>\n\
+      <Type Name=\"User\">\n  <DisplayString>{name={name} age={age} admin={admin} home={home}}</DisplayString>\n  <Expand>\n\
+      \    <Item Name=\"name\">name</Item>\n    <Item Name=\"age\">age</Item>\n    <Item Name=\"admin\">admin</Item>\n   \
+      \ <Item Name=\"home\">home</Item>\n  </Expand>\n</Type>"
+reflect-soa:
+  soa:
+    title: Soa
+    gcc_id: cjbasYYGd
+    gcc_url: https://godbolt.org/z/cjbasYYGd
+    gcc_expected_output: "Particle SoA layout:\n  std::vector<float> x;\n  std::vector<float> y;\n  std::vector<float> z;\n\
+      \  std::vector<float> vx;\n  std::vector<float> vy;\n  std::vector<float> vz;\nprocessed 100000 particles in SoA layout"


### PR DESCRIPTION
## Summary

- New non-aborting compatibility auditor `scripts/gcc-compatibility-report.py` walks all 28 example .cpp files, applies the `<experimental/meta>` -> `<meta>` rewrite, POSTs each to `g161` on Compiler Explorer, classifies (OK / OUTPUT_DRIFT / EXEC_FAIL / COMPILE_FAIL / NETWORK_ERR), and writes `docs/gcc-16-1-compatibility.md` with summary + per-post table + per-failure stderr + ships-on-both-vs-clang-only footer.
- Auto-populates `gcc_id` / `gcc_url` / `gcc_expected_output` in `src/data/godbolt-permalinks.yml` for every example that runs cleanly on GCC 16.1 (15 entries; idempotent re-runs skip already-shortened variants).
- New compiler-support badge in `src/components/GodboltEmbed.astro`: tiny italic line above the run buttons reading `Tested: clang-p2996 + GCC 16.1` when `gcc_id` is set, or `Tested: clang-p2996 only` otherwise. Hidden for TODO placeholders. `gcc_id` props wired into post-1 mdx (teaser + teaser_peel); post-2 was already wired.

## Audit results

**15 / 28 OK; 1 output-drift; 12 compile-fail; 0 exec-fail.**

Top failure categories:
- `api-name-diff` (9): GCC 16.1 ships `annotations_of_with_type` instead of clang's `annotation_of_type`; affects posts 1 (teaser_annotated, teaser_formats), 9, 11, 12, 13, 17, 19, 23, 24.
- `consteval-strict` (3): GCC stricter on `template for` over `members` (posts 3 splice_basics, 4 dump). Pure consteval-environment difference.
- `runtime-diff` (1): post 2 describe -- `libstdc++` mangles `std::__cxx11::basic_string<char>` vs `libc++`'s `basic_string<char, char_traits<char>, allocator<char>>`. Functional output, not a bug.

See [`docs/gcc-16-1-compatibility.md`](./docs/gcc-16-1-compatibility.md) for the full matrix and per-failure stderr.

## Badge UX

- Posts confirmed on both compilers (post 1 teaser/peel, post 2 describe): two stacked CTA buttons with the orange clang button on top, the blue GCC button below, and a tiny `Tested: clang-p2996 + GCC 16.1` badge above.
- Posts that are clang-only today (post 3 splicing, post 4 expansion, post 11 formats, ...): single orange button with `Tested: clang-p2996 only` above.
- TODO-placeholder embeds in unpublished posts 5-25 keep their existing placeholder card; no badge, since the YAML pickup happens at publish time.

## Test plan

- [x] `python3 scripts/gcc-compatibility-report.py` produces the .md and updates YAML idempotently.
- [x] `NODE_ENV=production npm run build` succeeds (94 pages built).
- [x] `dist/posts/why-cpp26-reflection-matters/index.html` shows `Tested: clang-p2996 + GCC 16.1` + the secondary `Also on GCC 16.1` button.
- [x] `dist/posts/splicing/index.html` shows `Tested: clang-p2996 only` + single button.