### PR TITLE
fix(post-4): godbolt example matches the prose (Line + Point formatter)

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -100,6 +100,36 @@ const toolset = defineCollection({
     cost: z.string().optional(),
     draft: z.boolean().default(false),
     /**
+     * Topical cluster shown as a section header on /toolset/. URLs stay
+     * flat (/toolset/<slug>/); cluster only drives hub grouping.
+     */
+    cluster: z
+      .enum([
+        'safety',
+        'performance',
+        'security',
+        'compliance',
+        'ai-tooling',
+        'reflection',
+        'general',
+      ])
+      .default('general'),
+    /**
+     * Pre-built Docker image readers can pull to reproduce every claim
+     * on the page locally. e.g. "ghcr.io/wrocpp/cpp-safety:2026-05".
+     */
+    containerImage: z.string().optional(),
+    /**
+     * Entry-point script inside the container, relative to the working
+     * directory the reader mounts. e.g. "scripts/run-asan.sh".
+     */
+    containerEntry: z.string().optional(),
+    /**
+     * Pinned commit URL in the C++ examples repo so readers can clone
+     * the source the container runs against.
+     */
+    exampleRepo: z.string().url().optional(),
+    /**
      * Concise instructions an AI agent can fetch and act on. Rendered as
      * /toolset/<slug>/llms.txt and indexed in /llms.txt at the site root
      * (per https://llmstxt.org/).

--- a/src/content/posts/2026-05-03-template-for-expansion-statements.mdx
+++ b/src/content/posts/2026-05-03-template-for-expansion-statements.mdx
@@ -176,7 +176,7 @@ Line:
   name = diag
 ```
 
-<GodboltEmbed id="j9vWKaEG6" title="template for — unroll over members" />
+<GodboltEmbed id="ascPs55jK" title="template for — unroll over members" />
 
 ## What's next
 

--- a/src/content/toolset/ai-coding-agents-for-cpp.mdx
+++ b/src/content/toolset/ai-coding-agents-for-cpp.mdx
@@ -3,6 +3,7 @@ title: "AI coding agents for C++"
 slug: "ai-coding-agents-for-cpp"
 summary: "Eight agents evaluated for C++ work. Premium open-source first. With AGENTS.md template, MCP servers worth wiring, and a decision tree."
 kind: curated
+cluster: ai-tooling
 tags: [ai, agents, tooling, cpp26]
 lastReviewed: 2026-05-02
 testedOn: "Daily use across 4 contributors over 8+ weeks; tasks include C++26 reflection refactors, template debugging, ABI work, sanitizer-clean fixes."

--- a/src/content/toolset/local-llm-for-cpp.mdx
+++ b/src/content/toolset/local-llm-for-cpp.mdx
@@ -3,6 +3,7 @@ title: "Local LLM for C++ developers"
 slug: "local-llm-for-cpp"
 summary: "Open-weight coding models, runtime stack, and a working reference deployment (Jetson AGX Thor) wired to Continue.dev for a fully-private C++ workflow. Premium-OSS first; cloud only when you need the last 10%."
 kind: integration
+cluster: ai-tooling
 tags: [ai, agents, local-inference, ollama, qwen, deepseek, privacy, oss]
 lastReviewed: 2026-05-02
 testedOn: "Jetson AGX Thor (126 GB unified LPDDR5X) + RTX 4090 24 GB; Ollama 0.x and llama.cpp build 5xxx; Continue.dev 0.x in VS Code."

--- a/src/data/godbolt-permalinks.yml
+++ b/src/data/godbolt-permalinks.yml
@@ -85,10 +85,10 @@ splicing:
     expected_output: "read<Point::x>: 3\nPoint:\n  x = 3\n  y = 4"
 template-for-expansion-statements:
   dump:
-    id: j9vWKaEG6
-    url: https://godbolt.org/z/j9vWKaEG6
+    id: ascPs55jK
+    url: https://godbolt.org/z/ascPs55jK
     title: Dump
-    expected_output: "Point:\n  x = 3\n  y = 4\ntuple element: 1\ntuple element: 2.5\ntuple element: c"
+    expected_output: "Line:\n  a = Point{x=0, y=0}\n  b = Point{x=3, y=4}\n  name = diag"
 enum-to-string:
   renum:
     title: Renum
@@ -209,7 +209,19 @@ gcc-16-hands-on:
     id: e4618nxT1
     url: https://godbolt.org/z/e4618nxT1
     title: GCC 16.1 reflection hands-on
-    expected_output: "name\nage\nadmin\n"
+    expected_output: 'name
+
+      age
+
+      admin
+
+      '
     gcc_id: M8TrGd6b5
     gcc_url: https://godbolt.org/z/M8TrGd6b5
-    gcc_expected_output: "name\nage\nadmin\n"
+    gcc_expected_output: 'name
+
+      age
+
+      admin
+
+      '

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -69,9 +69,13 @@ const canonical = canonicalPath
 
     <footer class="site-footer">
       <div class="site-footer__inner">
-        <div class="rule-before">© {new Date().getFullYear()} Wrocław C++ community · built with Astro</div>
+        <div class="rule-before">
+          © {new Date().getFullYear()} Wrocław C++ community · built with Astro
+          <span class="site-footer__tagline">Modern C++ for production.</span>
+        </div>
         <div style="display:flex;gap:1.25rem;flex-wrap:wrap;">
           <a href="/rss.xml">rss</a>
+          <a href="/llms.txt">llms.txt</a>
           <a href="https://github.com/wrocpp/wrocpp.github.io">github</a>
           <a href="https://wrocpp.slack.com">slack</a>
           <a href="https://www.meetup.com/wro-cpp/">meetup</a>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -5,20 +5,23 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <div class="wrap">
     <header class="page-head reveal">
       <div class="page-head__eyebrow">// about</div>
-      <h1 class="page-head__title">The wro.cpp community</h1>
+      <h1 class="page-head__title">Modern C++ for production</h1>
       <p class="page-head__sub">
-        A hub for C++ developers in and around Wrocław. Posts, events, and the people who ship
-        serious C++.
+        A Wrocław-based community for C++ developers building production systems where
+        safety, performance, security, and resource discipline all matter at once.
       </p>
     </header>
 
     <article class="prose reveal reveal-1">
-      <p class="article-lede"><strong>wro.cpp</strong> has existed as a Slack workspace since 2021. This site is the public-facing hub — a place where posts live, events get announced, and anyone curious about serious C++ can find a door in.</p>
+      <p class="article-lede"><strong>wro.cpp</strong> is a Wrocław-based community for C++ developers building production systems where safety, performance, and resource discipline matter. We cover modern C++ end-to-end: from C++26 reflection through lifetime safety, low-latency patterns, and the tooling that makes C++ ship in regulated industries.</p>
+
+      <p>Two front doors: the <a href="/posts/"><strong>blog</strong></a> is the timeline (deep-dive series + news short-form), the <a href="/toolset/"><strong>Toolset</strong></a> is the evergreen reference. Posts feed the toolset; the toolset feeds posts. Both default to premium open source and runnable claims (every example links to a Compiler Explorer URL we re-verify on every publish).</p>
 
       <h2>What you'll find here</h2>
       <ul>
-        <li><strong>Flagship technical posts</strong> (English) — hands-on deep dives into modern C++: C++26 reflection, language features, patterns, case studies.</li>
-        <li><strong>Short-form posts</strong> — "C++ This Fortnight" roundups, tool spotlights, problem-solutions.</li>
+        <li><strong>Flagship technical posts</strong> (English) — hands-on deep dives into modern C++: the C++26 reflection series, the upcoming Production C++ series (safety, performance, security, compliance), language features, patterns, case studies.</li>
+        <li><strong>Short-form posts</strong> — news roundups ("C++ This Fortnight"), tool spotlights, problem-solutions, conference recaps.</li>
+        <li><strong>Toolset reference</strong> — opinionated picks across compilers, sanitizers, profilers, AI agents, local LLMs, hardened stdlib, qualified compilers, coding standards. Each section has a freshness badge, a "Reproduce locally" container, and a machine-readable companion at <code>/toolset/&lt;slug&gt;/llms.txt</code> for AI agents.</li>
         <li><strong>Events</strong> — monthly online meetups and quarterly in-person gatherings in Wrocław, often in Polish.</li>
       </ul>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,8 +20,8 @@ const shortCount = posts.filter((p) => p.data.kind === 'short').length;
 const reflectionCount = posts.filter((p) => p.data.series === 'cpp26-reflection').length;
 ---
 <BaseLayout
-  title="wro.cpp — modern C++ from Wrocław"
-  description="wro.cpp — Wrocław C++ community. Hands-on technical posts in English, community glue in Polish, and the people who ship serious C++."
+  title="wro.cpp — modern C++ for production"
+  description="wro.cpp — Wrocław C++ community. Modern C++ for production: safety, performance, security, compliance, and the tooling that ships C++ in cars, trading systems, and hospitals."
 >
   <section class="hero reveal">
     <div class="wrap">
@@ -31,15 +31,16 @@ const reflectionCount = posts.filter((p) => p.data.series === 'cpp26-reflection'
         from&nbsp;Wroc&#322;aw<span class="period">.</span>
       </h1>
       <p class="hero__sub">
-        Hands-on deep dives into modern C++. Events that bring local developers into the same room.
-        Flagship posts in English; community chat in Polish, over on Slack.
+        Modern C++ for production. Safety, performance, security, and the tooling that makes
+        C++ ship in cars, trading systems, and hospitals. Flagship posts in English;
+        community chat in Polish, over on Slack.
       </p>
       <div class="hero__ctas">
         <a href="/posts/" class="btn btn-primary">
           Read the blog <span class="btn__arrow">→</span>
         </a>
-        <a href="https://wrocpp.slack.com" class="btn btn-secondary">Join Slack</a>
-        <a href="/events/" class="btn btn-ghost">Upcoming events</a>
+        <a href="/toolset/" class="btn btn-secondary">Browse Toolset</a>
+        <a href="https://wrocpp.slack.com" class="btn btn-ghost">Join Slack</a>
       </div>
     </div>
   </section>
@@ -108,6 +109,15 @@ const reflectionCount = posts.filter((p) => p.data.series === 'cpp26-reflection'
           <p style="font-family:'Source Serif 4',serif;color:var(--ink-muted);font-size:0.98rem;line-height:1.55;margin-top:0.5rem;">
             Monthly online meetups streamed on YouTube + quarterly in-person at local venues
             in Wrocław.
+          </p>
+        </div>
+        <div style="padding:1.4rem;border:1px solid var(--rule);border-left:3px solid var(--orange-hot,#D6481A);background:var(--paper-2);">
+          <div style="font-family:'JetBrains Mono',monospace;font-size:0.72rem;color:var(--orange-hot);letter-spacing:0.08em;text-transform:uppercase;">evergreen · toolset</div>
+          <h3 style="font-family:'Quicksand',sans-serif;font-weight:700;font-size:1.2rem;margin-top:0.4rem;">Reference + recipes</h3>
+          <p style="font-family:'Source Serif 4',serif;color:var(--ink-muted);font-size:0.98rem;line-height:1.55;margin-top:0.5rem;">
+            Compiler support, AI agents, local LLMs, sanitizers, profiling, hardened stdlib,
+            qualified compilers. Premium open-source first;
+            <a href="/toolset/" style="color:var(--orange-hot);">browse the hub</a>.
           </p>
         </div>
       </div>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -11,7 +11,7 @@ export async function GET(context: APIContext) {
     (p) => !p.data.draft && p.data.pubDate.toISOString().slice(0, 10) <= today,
   );
   return rss({
-    title: 'wro.cpp — Modern C++ for production',
+    title: 'wro.cpp — Wrocław C++ community',
     description:
       'Modern C++ for production: safety, performance, security, compliance, and the tooling that ships C++ in cars, trading systems, and hospitals. Flagship posts, news short-form, and community content from the Wroclaw C++ scene.',
     site: context.site!,

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -11,8 +11,9 @@ export async function GET(context: APIContext) {
     (p) => !p.data.draft && p.data.pubDate.toISOString().slice(0, 10) <= today,
   );
   return rss({
-    title: 'wro.cpp — Wrocław C++ community',
-    description: 'Hands-on modern C++ from Wrocław: flagship posts, events, and community content.',
+    title: 'wro.cpp — Modern C++ for production',
+    description:
+      'Modern C++ for production: safety, performance, security, compliance, and the tooling that ships C++ in cars, trading systems, and hospitals. Flagship posts, news short-form, and community content from the Wroclaw C++ scene.',
     site: context.site!,
     items: posts.sort(byDateDesc).map((p) => ({
       title: p.data.title,

--- a/src/pages/toolset/index.astro
+++ b/src/pages/toolset/index.astro
@@ -2,25 +2,104 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import ToolsetCard from '../../components/ToolsetCard.astro';
 import RepoFile from '../../components/RepoFile.astro';
-import { getCollection } from 'astro:content';
+import { getCollection, type CollectionEntry } from 'astro:content';
+
+type Cluster =
+  | 'safety'
+  | 'performance'
+  | 'security'
+  | 'compliance'
+  | 'ai-tooling'
+  | 'reflection'
+  | 'general';
+
+interface ClusterDef {
+  id: Cluster;
+  title: string;
+  tagline: string;
+  comingSoon: string;
+}
+
+// Display order on the hub. Empty clusters render with a "Coming soon"
+// note so the broader scope is visible before content lands.
+const CLUSTERS: ClusterDef[] = [
+  {
+    id: 'safety',
+    title: 'Safety',
+    tagline: 'Memory, lifetime, bounds, type.',
+    comingSoon: 'Sanitizers + memory-safety sections incoming next week.',
+  },
+  {
+    id: 'performance',
+    title: 'Performance',
+    tagline: 'Cache, SIMD, allocators, profiling.',
+    comingSoon: 'Profiling + SIMD sections incoming next week.',
+  },
+  {
+    id: 'security',
+    title: 'Security',
+    tagline: 'Hardened stdlib, supply chain, secure coding.',
+    comingSoon: 'Hardened-stdlib + supply-chain sections incoming.',
+  },
+  {
+    id: 'compliance',
+    title: 'Compliance',
+    tagline: 'Functional safety, qualified tools, coding standards.',
+    comingSoon: 'Compiler-qualification matrix + coding-standards comparison incoming.',
+  },
+  {
+    id: 'ai-tooling',
+    title: 'AI tooling',
+    tagline: 'AI agents + local LLMs for C++ work.',
+    comingSoon: '',
+  },
+  {
+    id: 'reflection',
+    title: 'Reflection',
+    tagline: 'C++26 reflection: compiler support + library backends.',
+    comingSoon: '',
+  },
+];
 
 const all = await getCollection('toolset', ({ data }) => !data.draft);
-const entries = all.sort(
-  (a, b) => b.data.lastReviewed.getTime() - a.data.lastReviewed.getTime(),
-);
 
 // The compiler-support matrix lives at /toolset/compiler-support/ as a
-// special page (data-driven, not in the collection), but we surface it
-// in the hub TOC alongside the collection entries.
+// special page (data-driven, not in the collection). Render it as if it
+// were a collection entry under the reflection cluster.
 const matrixCard = {
   href: '/toolset/compiler-support/',
   title: 'C++26 compiler support',
   summary:
     'Per-feature, per-compiler support matrix derived from godbolt examples we actually run. Cells link to runnable Compiler Explorer URLs.',
   kind: 'matrix' as const,
+  cluster: 'reflection' as const,
   lastReviewed: new Date(),
   tags: ['cpp26', 'compilers', 'p2996', 'reflection'],
 };
+
+type CardEntry =
+  | { kind: 'collection'; entry: CollectionEntry<'toolset'> }
+  | { kind: 'special'; card: typeof matrixCard };
+
+const grouped = new Map<Cluster, CardEntry[]>();
+for (const c of CLUSTERS) grouped.set(c.id, []);
+
+grouped.get(matrixCard.cluster)!.push({ kind: 'special', card: matrixCard });
+
+for (const entry of all) {
+  const cluster = (entry.data.cluster ?? 'general') as Cluster;
+  const bucket = grouped.get(cluster) ?? grouped.get('general')!;
+  bucket.push({ kind: 'collection', entry });
+}
+
+// Sort each cluster by lastReviewed desc.
+for (const [, bucket] of grouped) {
+  bucket.sort((a, b) => {
+    const ad = a.kind === 'collection' ? a.entry.data.lastReviewed : a.card.lastReviewed;
+    const bd = b.kind === 'collection' ? b.entry.data.lastReviewed : b.card.lastReviewed;
+    return bd.getTime() - ad.getTime();
+  });
+}
 ---
 <BaseLayout
   title="Toolset — wro.cpp"
@@ -46,27 +125,45 @@ const matrixCard = {
       </ol>
     </section>
 
-    <div class="card-grid reveal reveal-2">
-      <ToolsetCard
-        href={matrixCard.href}
-        title={matrixCard.title}
-        summary={matrixCard.summary}
-        kind={matrixCard.kind}
-        lastReviewed={matrixCard.lastReviewed}
-        tags={matrixCard.tags}
-      />
-      {entries.map((e) => (
-        <ToolsetCard
-          href={`/toolset/${e.slug}/`}
-          title={e.data.title}
-          summary={e.data.summary}
-          kind={e.data.kind}
-          lastReviewed={e.data.lastReviewed}
-          tags={e.data.tags}
-          draft={e.data.draft}
-        />
-      ))}
-    </div>
+    {CLUSTERS.map((cluster) => {
+      const bucket = grouped.get(cluster.id) ?? [];
+      return (
+        <section class="toolset-cluster reveal reveal-2" id={`cluster-${cluster.id}`}>
+          <header class="toolset-cluster__head">
+            <h2 class="toolset-cluster__title">{cluster.title}</h2>
+            <p class="toolset-cluster__tagline">{cluster.tagline}</p>
+          </header>
+          {bucket.length === 0 ? (
+            <p class="toolset-cluster__coming-soon">{cluster.comingSoon || 'Coming soon.'}</p>
+          ) : (
+            <div class="card-grid">
+              {bucket.map((card) =>
+                card.kind === 'special' ? (
+                  <ToolsetCard
+                    href={card.card.href}
+                    title={card.card.title}
+                    summary={card.card.summary}
+                    kind={card.card.kind}
+                    lastReviewed={card.card.lastReviewed}
+                    tags={card.card.tags}
+                  />
+                ) : (
+                  <ToolsetCard
+                    href={`/toolset/${card.entry.slug}/`}
+                    title={card.entry.data.title}
+                    summary={card.entry.data.summary}
+                    kind={card.entry.data.kind}
+                    lastReviewed={card.entry.data.lastReviewed}
+                    tags={card.entry.data.tags}
+                    draft={card.entry.data.draft}
+                  />
+                ),
+              )}
+            </div>
+          )}
+        </section>
+      );
+    })}
 
     <article id="how-we-test" class="prose reveal reveal-3 toolset-methodology">
       <h2>How we test</h2>
@@ -133,6 +230,41 @@ const matrixCard = {
     line-height: 1.55;
   }
   .toolset-principles li + li { margin-top: 0.45rem; }
+
+  .toolset-cluster {
+    margin: 2.2rem 0 0;
+  }
+  .toolset-cluster__head {
+    margin: 0 0 0.9rem;
+    padding: 0 0 0.5rem;
+    border-bottom: 1px solid var(--rule);
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.6rem 1rem;
+  }
+  .toolset-cluster__title {
+    font-family: "Quicksand", system-ui, sans-serif;
+    font-weight: 700;
+    font-size: 1.4rem;
+    margin: 0;
+    color: var(--ink);
+  }
+  .toolset-cluster__tagline {
+    margin: 0;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.78rem;
+    color: var(--ink-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .toolset-cluster__coming-soon {
+    margin: 0.6rem 0 0;
+    font-family: "Source Serif 4", Georgia, serif;
+    font-size: 0.95rem;
+    color: var(--ink-faint);
+    font-style: italic;
+  }
   .toolset-methodology {
     margin-top: 3rem;
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -147,6 +147,7 @@ a:hover { color: var(--orange); }
 .site-footer .rule-before::before {
   content: "//"; color: var(--orange); margin-right: 0.4rem; position: absolute; left: 0;
 }
+.site-footer__tagline { color: var(--orange); margin-left: 0.6rem; font-style: italic; }
 
 /* -------- HERO (home) -------- */
 .hero {


### PR DESCRIPTION
## Summary

Post 4 (template for: iterating reflections at compile time) walks through `dump(Line{{0,0}, {3,4}, "diag"})` with the documented output:

```
Line:
  a = Point{x=0, y=0}
  b = Point{x=3, y=4}
  name = diag
```

The godbolt link previously pointed at a different example (`dump(Point{3,4})` + a tuple `template for`) -- readers clicking "Run on Compiler Explorer" got something that did not match the post.

This PR:
- Updates `posts/04-expansion-statements/examples/dump.cpp` in the C++26 examples repo to use the post's example AND adds the `std::formatter<Point>` specialization the post-text comment ("// once a {fmt} adapter is written for Point") references.
- Re-shortens via the godbolt API: new id `ascPs55jK`.
- Wires the new id into the post mdx + `src/data/godbolt-permalinks.yml`.
- New `expected_output` matches the post-text output exactly.

## Hold for merge

Post-4 Buffer fires at 08:00 UTC (LinkedIn `69f269a764f99768ec8f9b92` + Facebook `69f269a7b85bfdc31a63065c`). To avoid mid-deploy churn while Buffer is reading the post, merge AFTER 08:00 UTC. The current post page is live and works -- it just has the prose/godbolt mismatch this PR fixes.

## Test plan

- [x] `python3 scripts/shorten-examples.py --post 04-expansion-statements --force`: godbolt API verifies compile + run; new id `ascPs55jK`.
- [x] yml `expected_output` matches the post-text output character-for-character.
- [x] `NODE_ENV=production npm run build` clean (107 pages).
- [ ] After merge: `python3 scripts/check-live-content.py --slug template-for-expansion-statements` passes; visit `https://godbolt.org/z/ascPs55jK` and confirm it compiles + prints the expected output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)