### PR TITLE
feat(godbolt): default shortlinks to executor pane (program output, not assembly)

### DIFF
--- a/scripts/shorten-examples.py
+++ b/scripts/shorten-examples.py
@@ -103,15 +103,36 @@ def slug_from_post(post_arg: str) -> tuple[str, str]:
 
 def shorten(source: str, title: str, profile: dict) -> dict:
     """Hit godbolt's shortener with one source file under the given
-    compiler profile. Returns the parsed {id, url, title}."""
+    compiler profile. Returns the parsed {id, url, title}.
+
+    Uses the `executors:` session shape (not `compilers:`) so the
+    permalink opens with the program's stdout pane on the right
+    instead of the assembly pane. The series's editorial promise is
+    "click and see what the program prints" -- assembly is rarely
+    what readers want first. Compile correctness is already gated by
+    compile_and_run() before this is called, so the executor pane
+    will never open onto a broken build."""
     payload = {
         "sessions": [
             {
                 "id": 1,
                 "language": "c++",
                 "source": source,
-                "compilers": [
-                    {"id": profile["id"], "options": profile["options"]}
+                "compilers": [],
+                "executors": [
+                    {
+                        "compiler": {
+                            "id": profile["id"],
+                            "options": profile["options"],
+                            "libs": [],
+                        },
+                        "compilerVisible": False,
+                        "compilerOutputVisible": False,
+                        "arguments": "",
+                        "argumentsVisible": False,
+                        "stdin": "",
+                        "stdinVisible": False,
+                    }
                 ],
             }
         ]

--- a/src/content/posts/2026-04-26-why-cpp26-reflection-matters.mdx
+++ b/src/content/posts/2026-04-26-why-cpp26-reflection-matters.mdx
@@ -116,7 +116,7 @@ std::string to_json(T const& obj) {
 }
 ```
 
-<GodboltEmbed id="n4eK93vfv" gcc_id="e3346Pxoh" title="40-line JSON serializer" />
+<GodboltEmbed id="3bjshh58z" gcc_id="fKfr3fs33" title="40-line JSON serializer" />
 
 Five new things are happening:
 
@@ -186,7 +186,7 @@ Three things make this work, and it's worth naming each:
 
 After `-O2`, the codegen is effectively identical — the optimiser proves the `first` flag's value per unrolled iteration and elides the branches either way. The win isn't runtime cost; it's source-level intent. The peel version has zero branches in the source, handles empty structs explicitly via `if constexpr`, and reads like "first, then rest" instead of "carry a flag".
 
-<GodboltEmbed id="MzM4bh3rj" gcc_id="439ro4sno" title="Peel-first variant — first iteration hoisted to compile time" />
+<GodboltEmbed id="xTqP948nc" gcc_id="6bbMhnTW7" title="Peel-first variant — first iteration hoisted to compile time" />
 
 ---
 

--- a/src/content/posts/2026-04-29-first-reflection.mdx
+++ b/src/content/posts/2026-04-29-first-reflection.mdx
@@ -119,7 +119,7 @@ y: int
 
 Twelve meaningful lines. No macros, no external tool, no `#define BOOST_...`.
 
-<GodboltEmbed id="bq9WjeeM5" gcc_id="n86cE3aWq" title="Your first ^^ — walking Point's members" />
+<GodboltEmbed id="3nbdxxW91" gcc_id="1dGWqr35z" title="Your first ^^ — walking Point's members" />
 
 ## The primitives you just used
 

--- a/src/content/posts/2026-05-01-splicing.mdx
+++ b/src/content/posts/2026-05-01-splicing.mdx
@@ -158,7 +158,7 @@ int main() {
 
 `dump_field<m>` — we pass the reflection as a template argument so `M` is a constant expression inside the helper, and `obj.[:M:]` is a real member access the compiler can check.
 
-<GodboltEmbed id="TnMx1Ys5b" title="Splicing — reflections back to code" />
+<GodboltEmbed id="bhdq9We19" title="Splicing — reflections back to code" />
 
 ## What splicing isn't
 

--- a/src/content/posts/2026-05-03-template-for-expansion-statements.mdx
+++ b/src/content/posts/2026-05-03-template-for-expansion-statements.mdx
@@ -176,7 +176,7 @@ Line:
   name = diag
 ```
 
-<GodboltEmbed id="ascPs55jK" title="template for — unroll over members" />
+<GodboltEmbed id="asx7hs1qz" title="template for — unroll over members" />
 
 ## What's next
 

--- a/src/content/posts/2026-05-04-gcc-16-hands-on.mdx
+++ b/src/content/posts/2026-05-04-gcc-16-hands-on.mdx
@@ -75,7 +75,7 @@ GCC 16.1 ships only the canonical `<meta>` header; the `<experimental/meta>` spe
 
 If you don't want to install anything, the button below opens the same source pre-loaded on Compiler Explorer -- one click for clang-p2996, one click for GCC 16.1. Identical output on both.
 
-<GodboltEmbed id="e4618nxT1" gcc_id="M8TrGd6b5" title="GCC 16.1 reflection hands-on (25 lines)" />
+<GodboltEmbed id="qfcrrYT3d" gcc_id="6fbT9azrY" title="GCC 16.1 reflection hands-on (25 lines)" />
 
 ## Where to next
 

--- a/src/content/posts/2026-09-16-one-codegen-many-formats.mdx
+++ b/src/content/posts/2026-09-16-one-codegen-many-formats.mdx
@@ -237,7 +237,7 @@ std::println("{}", rserial::to_yaml(u));
 std::println("{}", rserial::to_xml(u));
 ```
 
-<GodboltEmbed id="WKhjGxE7K" title="One struct → JSON, YAML, XML" />
+<GodboltEmbed id="vPrq7n3on" title="One struct → JSON, YAML, XML" />
 
 ## What's next
 

--- a/src/data/godbolt-permalinks.yml
+++ b/src/data/godbolt-permalinks.yml
@@ -9,39 +9,39 @@
 
 why-cpp26-reflection-matters:
   teaser:
-    id: n4eK93vfv
-    url: https://godbolt.org/z/n4eK93vfv
+    id: 3bjshh58z
+    url: https://godbolt.org/z/3bjshh58z
     title: 40-line JSON serializer with reflection
     expected_output: '{"name":"Filip","age":40,"admin":true,"home":{"city":"Warsaw","postal_code":12345}}'
-    gcc_id: e3346Pxoh
-    gcc_url: https://godbolt.org/z/e3346Pxoh
+    gcc_id: fKfr3fs33
+    gcc_url: https://godbolt.org/z/fKfr3fs33
     gcc_expected_output: '{"name":"Filip","age":40,"admin":true,"home":{"city":"Warsaw","postal_code":12345}}'
   teaser_peel:
-    id: MzM4bh3rj
-    url: https://godbolt.org/z/MzM4bh3rj
+    id: xTqP948nc
+    url: https://godbolt.org/z/xTqP948nc
     title: "Peel-first variant \u2014 first iteration hoisted to compile time"
     expected_output: '{"name":"Filip","age":40,"admin":true,"home":{"city":"Warsaw","postal_code":12345}}'
-    gcc_id: 439ro4sno
-    gcc_url: https://godbolt.org/z/439ro4sno
+    gcc_id: 6bbMhnTW7
+    gcc_url: https://godbolt.org/z/6bbMhnTW7
     gcc_expected_output: '{"name":"Filip","age":40,"admin":true,"home":{"city":"Warsaw","postal_code":12345}}'
   teaser_annotated:
-    id: 97WdeKs7v
-    url: https://godbolt.org/z/97WdeKs7v
+    id: jG7cr9zab
+    url: https://godbolt.org/z/jG7cr9zab
     title: "Annotated serializer \u2014 rename, skip, skip-if-empty, rename_all"
     expected_output: '{"userName":"filip","id":42,"email":"filip@example.com","bio":"hello","isAdmin":true}
 
       {"userName":"anon","id":7,"email":"a@b.c","isAdmin":false}'
   teaser_formats:
-    id: WKhjGxE7K
-    url: https://godbolt.org/z/WKhjGxE7K
+    id: vPrq7n3on
+    url: https://godbolt.org/z/vPrq7n3on
     title: "One reflection walk, three formats: JSON \xB7 YAML \xB7 XML"
     expected_output: "--- JSON ---\n{\"userName\":\"filip\",\"id\":42,\"email\":\"filip@example.com\",\"isAdmin\":true,\"\
       homeAddress\":{\"city\":\"Warsaw\",\"postal_code\":12345}}\n\n--- YAML ---\nuserName: filip\nid: 42\nemail: filip@example.com\n\
       isAdmin: true\nhomeAddress: \n  city: Warsaw\n  postal_code: 12345\n\n--- XML  ---\n<userName>filip</userName><id>42</id><email>filip@example.com</email><isAdmin>true</isAdmin><homeAddress><city>Warsaw</city><postal_code>12345</postal_code></homeAddress>"
 first-reflection:
   describe:
-    id: bq9WjeeM5
-    url: https://godbolt.org/z/bq9WjeeM5
+    id: 3nbdxxW91
+    url: https://godbolt.org/z/3nbdxxW91
     title: Describe
     expected_output: 'Point:
 
@@ -59,8 +59,8 @@ first-reflection:
       name: basic_string<char, char_traits<char>, allocator<char>>
 
       '
-    gcc_id: n86cE3aWq
-    gcc_url: https://godbolt.org/z/n86cE3aWq
+    gcc_id: 1dGWqr35z
+    gcc_url: https://godbolt.org/z/1dGWqr35z
     gcc_expected_output: 'Point:
 
       x: int
@@ -79,35 +79,35 @@ first-reflection:
       '
 splicing:
   splice_basics:
-    id: TnMx1Ys5b
-    url: https://godbolt.org/z/TnMx1Ys5b
+    id: bhdq9We19
+    url: https://godbolt.org/z/bhdq9We19
     title: Splice basics
     expected_output: "read<Point::x>: 3\nPoint:\n  x = 3\n  y = 4"
 template-for-expansion-statements:
   dump:
-    id: ascPs55jK
-    url: https://godbolt.org/z/ascPs55jK
+    id: asx7hs1qz
+    url: https://godbolt.org/z/asx7hs1qz
     title: Dump
     expected_output: "Line:\n  a = Point{x=0, y=0}\n  b = Point{x=3, y=4}\n  name = diag"
 enum-to-string:
   renum:
     title: Renum
-    gcc_id: cTKnshToM
-    gcc_url: https://godbolt.org/z/cTKnshToM
+    gcc_id: o6njP4GeE
+    gcc_url: https://godbolt.org/z/o6njP4GeE
     gcc_expected_output: 'green
 
       read|exec'
 auto-formatter:
   formatter:
     title: Formatter
-    gcc_id: Y5ohxse9d
-    gcc_url: https://godbolt.org/z/Y5ohxse9d
+    gcc_id: Wbeq4oEP5
+    gcc_url: https://godbolt.org/z/Wbeq4oEP5
     gcc_expected_output: 'User{name: Filip, age: 40, admin: true, home: Address{city: Warsaw, postal_code: 12345}}'
 derive-eq-hash:
   hash_demo:
     title: Hash demo
-    gcc_id: Eada5fhx6
-    gcc_url: https://godbolt.org/z/Eada5fhx6
+    gcc_id: 43WMPKPMq
+    gcc_url: https://godbolt.org/z/43WMPKPMq
     gcc_expected_output: '(3,4) -> 3-4-5
 
       (0,0) -> origin
@@ -118,28 +118,28 @@ derive-eq-hash:
 json-naive:
   rjson:
     title: Rjson
-    gcc_id: PnzTqMPbP
-    gcc_url: https://godbolt.org/z/PnzTqMPbP
+    gcc_id: GTo4hMn56
+    gcc_url: https://godbolt.org/z/GTo4hMn56
     gcc_expected_output: '{"name":"Filip","age":40,"admin":true,"home":{"city":"Warsaw","postal_code":12345},"aliases":["fsjdk","phi"]}'
 json-deserialize:
   from_values:
     title: From values
-    gcc_id: f5dvhjMdP
-    gcc_url: https://godbolt.org/z/f5dvhjMdP
+    gcc_id: qKK7v4vdE
+    gcc_url: https://godbolt.org/z/qKK7v4vdE
     gcc_expected_output: "name=Filip age=40 admin=true\nfailure path: at .age \u2014 expected number"
 dependency-injection:
   di_demo:
     title: Di demo
-    gcc_id: zqs9vn7vo
-    gcc_url: https://godbolt.org/z/zqs9vn7vo
+    gcc_id: Wb6zPa1Ex
+    gcc_url: https://godbolt.org/z/Wb6zPa1Ex
     gcc_expected_output: 'Hello @tick=1
 
       Hello @tick=2'
 auto-mocks:
   mock_demo:
     title: Mock demo
-    gcc_id: qW9vYcTTj
-    gcc_url: https://godbolt.org/z/qW9vYcTTj
+    gcc_id: jbeWEa3ex
+    gcc_url: https://godbolt.org/z/jbeWEa3ex
     gcc_expected_output: 'now:  42
 
       zone: Europe/Warsaw
@@ -152,22 +152,22 @@ auto-mocks:
 define-aggregate:
   pick:
     title: Pick
-    gcc_id: xTxofns9E
-    gcc_url: https://godbolt.org/z/xTxofns9E
+    gcc_id: 3o8T5h1od
+    gcc_url: https://godbolt.org/z/3o8T5h1od
     gcc_expected_output: "Pick<User, \"name\", \"age\", \"admin\"> would contain:\n  name : std::__cxx11::basic_string<char>\n\
       \  age : int\n  admin : bool\n(Type synthesis via std::meta::define_aggregate is experimental;\n full Pick / Omit /\
       \ Partial land once the compiler context relaxes.)"
 cross-language-comparison:
   main:
     title: Main
-    gcc_id: GYT781eY5
-    gcc_url: https://godbolt.org/z/GYT781eY5
+    gcc_id: hrhqnT8x7
+    gcc_url: https://godbolt.org/z/hrhqnT8x7
     gcc_expected_output: '{"name":"Filip","age":40,"admin":true}'
 reflect-arbitrary:
   arbitrary:
     title: Arbitrary
-    gcc_id: 8nEcd6zce
-    gcc_url: https://godbolt.org/z/8nEcd6zce
+    gcc_id: hddrxnPK9
+    gcc_url: https://godbolt.org/z/hddrxnPK9
     gcc_expected_output: 'Generated User #0: name=uy       age=18  admin=true home={city=ppel pc=15}
 
       Generated User #1: name=b        age=46  admin=true home={city=pd pc=71}
@@ -180,8 +180,8 @@ reflect-arbitrary:
 reflect-optics:
   optics:
     title: Optics
-    gcc_id: bsErWaTex
-    gcc_url: https://godbolt.org/z/bsErWaTex
+    gcc_id: qx6Ksesa7
+    gcc_url: https://godbolt.org/z/qx6Ksesa7
     gcc_expected_output: 'view: Wroclaw
 
       set:  Warsaw
@@ -190,8 +190,8 @@ reflect-optics:
 reflect-dx:
   natvis_emit:
     title: Natvis emit
-    gcc_id: s3GzrhjvM
-    gcc_url: https://godbolt.org/z/s3GzrhjvM
+    gcc_id: 6oWoT8ac7
+    gcc_url: https://godbolt.org/z/6oWoT8ac7
     gcc_expected_output: "<Type Name=\"Address\">\n  <DisplayString>{city={city} postal_code={postal_code}}</DisplayString>\n\
       \  <Expand>\n    <Item Name=\"city\">city</Item>\n    <Item Name=\"postal_code\">postal_code</Item>\n  </Expand>\n</Type>\n\
       <Type Name=\"User\">\n  <DisplayString>{name={name} age={age} admin={admin} home={home}}</DisplayString>\n  <Expand>\n\
@@ -200,14 +200,14 @@ reflect-dx:
 reflect-soa:
   soa:
     title: Soa
-    gcc_id: cjbasYYGd
-    gcc_url: https://godbolt.org/z/cjbasYYGd
+    gcc_id: nj7GEEEzY
+    gcc_url: https://godbolt.org/z/nj7GEEEzY
     gcc_expected_output: "Particle SoA layout:\n  std::vector<float> x;\n  std::vector<float> y;\n  std::vector<float> z;\n\
       \  std::vector<float> vx;\n  std::vector<float> vy;\n  std::vector<float> vz;\nprocessed 100000 particles in SoA layout"
 gcc-16-hands-on:
   hello_reflect:
-    id: e4618nxT1
-    url: https://godbolt.org/z/e4618nxT1
+    id: qfcrrYT3d
+    url: https://godbolt.org/z/qfcrrYT3d
     title: GCC 16.1 reflection hands-on
     expected_output: 'name
 
@@ -216,8 +216,8 @@ gcc-16-hands-on:
       admin
 
       '
-    gcc_id: M8TrGd6b5
-    gcc_url: https://godbolt.org/z/M8TrGd6b5
+    gcc_id: 6fbT9azrY
+    gcc_url: https://godbolt.org/z/6fbT9azrY
     gcc_expected_output: 'name
 
       age


### PR DESCRIPTION
## Summary

Compiler Explorer permalinks we generate now open with the program's stdout pane on the right, instead of the x86-64 assembly view. Matches the editorial promise "click and see what the program prints" -- assembly is rarely what readers reach for first.

### What changed

- `scripts/shorten-examples.py`: session payload swaps \`compilers: [...]\` for \`executors: [...]\`. The compile-and-run gate already runs before shortening, so the executor pane is guaranteed to land on a working build.
- All 25 existing godbolt IDs regenerated under the new layout (17 reflection-series slugs + 1 news post, clang-p2996 and GCC 16.1 where each applies).
- 6 mdx files swept to wire the new IDs:
  - Post 1 (why-cpp26-reflection-matters): 4 IDs
  - Post 2 (first-reflection): 2 IDs
  - Post 3 (splicing): 1 ID
  - Post 4 (template-for-expansion-statements): 1 ID
  - News (gcc-16-hands-on): 2 IDs
  - Forward-link in post 11 (one-codegen-many-formats): 1 ID

### Heads-up

Old shortlink URLs (n4eK93vfv, e3346Pxoh, MzM4bh3rj, 439ro4sno, 97WdeKs7v, WKhjGxE7K, bq9WjeeM5, n86cE3aWq, TnMx1Ys5b, ascPs55jK, cTKnshToM, Y5ohxse9d, Eada5fhx6, PnzTqMPbP, f5dvhjMdP, zqs9vn7vo, qW9vYcTTj, xTxofns9E, GYT781eY5, 8nEcd6zce, bsErWaTex, s3GzrhjvM, cjbasYYGd, e4618nxT1, M8TrGd6b5) return 404 after merge. Anyone with a bookmark hits a dead link; they reach the new shortlinks via the post pages.

Sample new shortlink (post 4): https://godbolt.org/z/asx7hs1qz -- click and confirm: code on left, "Program returned: 0" + program stdout on right, no assembly pane.

## Test plan

- [x] \`NODE_ENV=production npm run build\` clean (107 pages)
- [x] godbolt API \`shortlinkinfo\` confirms new payload renders \`executors: [...]\`, no \`compilers:\`
- [x] Verified: post 4's new shortlink opens with the executor pane, prints expected output
- [ ] Manual: open one new shortlink per LIVE post (1, 2, 3, 4, gcc-16-hands-on); confirm each lands on the executor view, not the asm view
- [ ] After merge: \`python3 scripts/check-live-content.py --slug <each>\` for live posts; visit live post pages and confirm "Run on Compiler Explorer" buttons go somewhere useful

🤖 Generated with [Claude Code](https://claude.com/claude-code)