### PR TITLE
publish(post-5): enum-to-string flips to draft:false (fires Tue 5/5 10:00 CEST)

### DIFF
--- a/src/content/posts/2026-06-24-enum-to-string.mdx
+++ b/src/content/posts/2026-06-24-enum-to-string.mdx
@@ -10,7 +10,8 @@ series_order: 5
 audience: working-cpp
 tags: [reflection, cpp26, enum, magic_enum]
 summary: "A reflection-driven enum↔string library in 30 lines. No __PRETTY_FUNCTION__ tricks, no compile-time range knob, no compiler-specific behaviour — and unbounded, including enum values beyond 128."
-draft: true
+draft: false
+discussion: https://github.com/wrocpp/wrocpp.github.io/discussions/42
 ---
 
 import GodboltEmbed from '../../components/GodboltEmbed.astro';


### PR DESCRIPTION
## Summary
Flips `draft: true -> false` on `enum-to-string` (series post 5). Page is gated by `isPublished` until pubDate (Tue 2026-05-05 00:00) so the live URL appears overnight.

Discussion thread auto-created: #42 -> wired into frontmatter.

## Test plan
- [x] `npm run build` clean (115 pages)
- [x] `check-post-links.py` reports the expected isPublished gating (page absent from dist today, will appear at midnight)
- [x] godbolt embed `qfKMzGzj8` verified runs end-to-end (round-trip + typo rejection demos)

Companion c++26 PR (#5) merged earlier today with the example refresh.