### PR TITLE
publish(posts 6+7): flip drafts + captions + MR4.5 launch wiring

### DIFF
--- a/social/facebook/auto-formatter/caption.md
+++ b/social/facebook/auto-formatter/caption.md
@@ -1,0 +1,18 @@
+# Reflect_print: auto std::formatter for any aggregate
+
+## Body
+Rust has `#[derive(Debug)]`. C++ until 2026 had `operator<<` written by hand per type. C++26 reflection ends that: one `std::formatter` specialisation walks any aggregate at compile time and prints all fields with names. Nested aggregates print recursively. Rename a field -- print follows.
+
+Series post 6 of 25 in the wro.cpp C++26 reflection arc. Live demo on Godbolt.
+
+https://wrocpp.github.io/posts/auto-formatter/
+
+## Hashtags
+#cpp #cpp26 #reflection #format #wrocpp #moderncpp
+
+## Alt-text
+Dark editorial card with the wro.cpp magnet wordmark. Headline: "Reflect_print: auto std::formatter for any aggregate". Subhead: One header replaces every operator<< and fmt specialisation. Citation: wro.cpp 2026-05-07.
+
+## Suggested post time
+Thursday 2026-05-07, 10:00 CET
+Reason: Mid-week morning slot for EU C++ audience.

--- a/social/facebook/derive-eq-hash/caption.md
+++ b/social/facebook/derive-eq-hash/caption.md
@@ -1,0 +1,18 @@
+# Derive eq + hash from struct shape
+
+## Body
+C++20's `operator==() = default` covers two-thirds of what value types need; `std::hash<T>` is still hand-written. C++26 reflection fills the gap: one header walks any aggregate and emits hash + per-field-annotated equality (epsilon for floats, skip flags, normalise-first). Schema-as-spec for value semantics.
+
+Series post 7 of 25 in the wro.cpp C++26 reflection arc. Live demo on Godbolt.
+
+https://wrocpp.github.io/posts/derive-eq-hash/
+
+## Hashtags
+#cpp #cpp26 #reflection #hash #wrocpp #moderncpp
+
+## Alt-text
+Dark editorial card with the wro.cpp magnet wordmark. Headline: "Derive eq + hash + ordering from struct shape". Subhead: Reflection fills the std::hash gap with per-field annotations for epsilon, normalisation, skip. Citation: wro.cpp 2026-05-09.
+
+## Suggested post time
+Saturday 2026-05-09, 10:00 CET
+Reason: Saturday morning slot for EU C++ audience.

--- a/social/facebook/testing-for-safety-2026/caption.md
+++ b/social/facebook/testing-for-safety-2026/caption.md
@@ -1,0 +1,18 @@
+# Testing for safety in 2026
+
+## Body
+A test that writes 42 to a field and reads it back tests C++ assignment, not your code. Today's wro.cpp Toolset launch covers the four coverage levels (Catch2 / RapidCheck / libFuzzer / differential) plus two reflection-driven patterns where C++26 genuinely earns its keep: `arbitrary<T>` (the C++ analogue of Rust derive(Arbitrary), keeps production types clean via sidecar TestSpec specialisations), and `pretty_diff` (~30 lines of structural failure diagnostics, "T != T" becomes "field raw_value: 12345 != 12344").
+
+Honest about scope: GoogleMock-style behavior mocks stay better in their frameworks until C++29 token-injection (P3294) lands.
+
+https://wrocpp.github.io/toolset/testing-for-safety-2026/
+
+## Hashtags
+#cpp #cpp26 #reflection #testing #wrocpp #moderncpp
+
+## Alt-text
+Dark editorial card with the wro.cpp magnet wordmark. Headline: "Testing for safety in 2026". Subhead: Catch2 / RapidCheck / libFuzzer + reflection-driven arbitrary<T> + structural pretty_diff. Citation: wro.cpp 2026-05-16.
+
+## Suggested post time
+Saturday 2026-05-16, 10:00 CET
+Reason: Saturday morning slot for EU C++ audience. MR4.5 toolset launch.

--- a/social/linkedin/auto-formatter/caption.md
+++ b/social/linkedin/auto-formatter/caption.md
@@ -1,0 +1,35 @@
+# Reflect_print: auto std::formatter for any aggregate
+
+## Body
+Rust gives you `#[derive(Debug)]`. C++ gave you `operator<<` per type, written by hand. C++26 reflection closes the gap with one header.
+
+`reflect_print<T>` walks any aggregate at compile time and emits a `std::format` specialisation that prints all fields with their names. Recursive: nested aggregates are formatted in turn. Add a field, the print follows automatically -- no hand-maintained overload, no codegen step.
+
+```cpp
+struct Address { std::string city; int postal_code; };
+struct User { std::string name; int age; bool admin; Address home; };
+
+User u{"Filip", 40, true, {"Warsaw", 12345}};
+std::println("{}", u);
+// User{name: Filip, age: 40, admin: true, home: Address{city: Warsaw, postal_code: 12345}}
+```
+
+The trick is a `template <typename T> struct std::formatter` specialisation written ONCE for any aggregate, with the field walk inside `format()` driven by `nonstatic_data_members_of(^^T)`. Rename a field -- print follows. Add an int member -- it shows up. Remove one -- it disappears. The string output is structural, not editorial; for journals and audit logs that's exactly what you want.
+
+What this replaces: every `operator<<(std::ostream&, T const&)` overload in your codebase, plus all the `fmt::format` per-type specialisations you've been maintaining.
+
+What this does NOT replace: hand-tuned print formats (custom field separators, omitting boilerplate fields, redacting secrets). Those still need a manual `std::formatter` specialisation. The default exists for the common case: structured printing of every field, every time, kept in sync with the schema.
+
+Series post 6 of 25 in the wro.cpp C++26 reflection arc. Live demo on Godbolt with GCC 16.1 (`-std=c++26 -freflection`).
+
+https://wrocpp.github.io/posts/auto-formatter/
+
+## Hashtags
+#cpp #cpp26 #reflection #format #fmt #wrocpp #moderncpp
+
+## Alt-text
+Dark editorial card with the wro.cpp magnet wordmark. Headline: "Reflect_print: auto std::formatter for any aggregate". Subhead: One header replaces every operator<< and fmt specialisation; nested aggregates print recursively. Citation: wro.cpp 2026-05-07.
+
+## Suggested post time
+Thursday 2026-05-07, 10:00 CET
+Reason: Mid-week morning slot reaches EU C++ engineers in flow. Reflection-arc post 6 follows post 5's launch on Tue 5/5; consistent every-other-day cadence.

--- a/social/linkedin/derive-eq-hash/caption.md
+++ b/social/linkedin/derive-eq-hash/caption.md
@@ -1,0 +1,39 @@
+# Derive eq + hash + ordering from struct shape
+
+## Body
+C++20's `bool operator==(T const&) const = default` covers two-thirds of what value types need. The missing third is `std::hash<T>` -- which still requires a manual specialisation for every aggregate you put in an `unordered_map` -- and per-field customisation (skip a field, compare a `double` within epsilon, normalise a string before hashing) that defaulted ops can't express.
+
+C++26 reflection fills both gaps. One header (`reflect_eq`):
+
+```cpp
+template <typename T>
+struct std::hash<T> {  // for any reflectable aggregate
+    constexpr std::size_t operator()(T const& x) const noexcept {
+        std::size_t h = 0;
+        template for (constexpr auto m : nonstatic_data_members_of<T>()) {
+            h ^= std::hash<[:type_of(m):]>{}(x.[:m:]) + 0x9e3779b9 + (h<<6) + (h>>2);
+        }
+        return h;
+    }
+};
+```
+
+Rename a field -- hash follows. Add a member -- it's included. Same shape with annotations for opt-in customisation: `[[skip_in_hash]]`, `[[approx_eq(0.001)]]`, `[[normalise_first]]` mark per-field policy that the generic `operator==` and `hash` honor at compile time. Schema-as-spec: edit the struct, the comparison and hash stay correct.
+
+The post also covers the gotchas: float comparison defaults are fragile (use epsilon annotations); std::hash mixing with the FNV-style boilerplate above is OK for hashmaps but NOT for cryptographic use; defaulted `operator<=>` interacts subtly with annotated equality.
+
+What this replaces: every hand-maintained `std::hash<T>` specialisation, every "did I update both eq and hash when I added a field?" review comment.
+
+Series post 7 of 25 in the wro.cpp C++26 reflection arc. Live demo on Godbolt with GCC 16.1.
+
+https://wrocpp.github.io/posts/derive-eq-hash/
+
+## Hashtags
+#cpp #cpp26 #reflection #hash #equality #wrocpp #moderncpp
+
+## Alt-text
+Dark editorial card with the wro.cpp magnet wordmark. Headline: "Derive eq + hash + ordering from struct shape". Subhead: Reflection fills the std::hash gap that C++20's defaulted operator== left; per-field annotations for epsilon, normalisation, skip. Citation: wro.cpp 2026-05-09.
+
+## Suggested post time
+Saturday 2026-05-09, 10:00 CET
+Reason: Saturday morning catches weekend reading-list builders. Reflection-arc post 7; consistent every-other-day cadence.

--- a/social/linkedin/testing-for-safety-2026/caption.md
+++ b/social/linkedin/testing-for-safety-2026/caption.md
@@ -1,0 +1,28 @@
+# Testing for safety in 2026 -- the four coverage levels and the reflection-driven shortcut
+
+## Body
+A test that writes `42` to a field and reads it back tests C++ assignment, not the production code. Real-world bugs are different shapes: parsers and serializers drift apart after one of them gains a field; an interface gains a method but only half its mocks know; the diagnostic on a failed assertion says "T != T" and you reach for a debugger.
+
+C++26 reflection is the right shape for the bugs that follow mechanically from struct layout. Two patterns where reflection-alone genuinely earns its keep:
+
+**arbitrary&lt;T&gt;** -- the C++ analogue of Rust's `#[derive(Arbitrary)]` and Haskell QuickCheck's `Generic` instances. Generic typed input generator. Production type stays clean; test code specialises `template <> struct TestSpec<T>` (mirroring std::hash / std::formatter), keyed by member-pointer NTTPs (`&T::field`), so renaming a production field breaks the spec at build time. The kernel walks the spec, returns the cross-product of per-field samples. Round-trip property test, fuzz harness, fixture factory, differential tests are short layers on top.
+
+**pretty_diff** -- structural failure diagnostics. ~30 lines of library, walks any T at compile time, emits `field K: A != B` on assertion failure instead of the unreadable `T != T`. Replaces the hand-maintained dump.hpp every codebase grows and forgets to update.
+
+Today's wro.cpp Toolset launch (MR4.5 in the safety cluster) covers all of it -- the four-level coverage ladder (Catch2/doctest/GoogleTest -> RapidCheck -> libFuzzer/AFL++ -> differential), the reflection patterns above with proper layering (production stays clean, test concerns in test code), and the C++29 token-injection direction (P3294) that finally makes mock synthesis competitive with GoogleMock.
+
+What reflection-alone is NOT for: GoogleMock-style behavior mocks. Honest framing in the post -- the page says outright that argument matchers, sequenced expectations, and action wiring stay better in those frameworks until C++29 injection lands.
+
+Cross-linked with sanitizers-2026 (the runtime safety net these tests feed) and memory-safety-cpp26-and-beyond (compile-time enforcement story).
+
+https://wrocpp.github.io/toolset/testing-for-safety-2026/
+
+## Hashtags
+#cpp #cpp26 #reflection #testing #propertybased #fuzzing #wrocpp #moderncpp
+
+## Alt-text
+Dark editorial card with the wro.cpp magnet wordmark. Headline: "Testing for safety in 2026". Subhead: Catch2 / RapidCheck / libFuzzer / differential coverage ladder + reflection-driven arbitrary<T> kernel + structural pretty_diff. Citation: wro.cpp 2026-05-16.
+
+## Suggested post time
+Saturday 2026-05-16, 10:00 CET
+Reason: Saturday morning catches weekend reading-list builders. MR4.5 toolset launch in the safety cluster; pairs with MR4 (Thu 5/14 memory-safety-cpp26-and-beyond) for the full safety triptych.

--- a/src/content/posts/2026-07-08-auto-formatter.mdx
+++ b/src/content/posts/2026-07-08-auto-formatter.mdx
@@ -10,7 +10,8 @@ series_order: 6
 audience: working-cpp
 tags: [reflection, cpp26, formatter, debug-print, reflect_print]
 summary: "Rust's #[derive(Debug)] in C++: make any struct printable via std::format and std::println by dropping in one partial specialisation of std::formatter. Nested types, containers, enum names — all handled."
-draft: true
+draft: false
+discussion: https://github.com/wrocpp/wrocpp.github.io/discussions/45
 ---
 
 import GodboltEmbed from '../../components/GodboltEmbed.astro';
@@ -186,7 +187,7 @@ Our version: no field limit, preserves names, `is_aggregate_v` constraint produc
 
 The `{fmt}` library has `FMT_FORMAT_AS(T, ...)` macros for teaching `fmt::format` how to print a type. They're great but per-type. Reflection replaces them with a single partial specialisation.
 
-<GodboltEmbed id="TODOfmt" title="reflect_print — auto std::formatter for any aggregate" />
+<GodboltEmbed id="Wbeq4oEP5" title="reflect_print — auto std::formatter for any aggregate" />
 
 ## What's next
 

--- a/src/content/posts/2026-07-22-derive-eq-hash.mdx
+++ b/src/content/posts/2026-07-22-derive-eq-hash.mdx
@@ -10,7 +10,8 @@ series_order: 7
 audience: working-cpp
 tags: [reflection, cpp26, equality, hash, ordering]
 summary: "C++20 gave us `= default` for operator== and <=>. Reflection lets us do the same for hashing, plus go beyond default: include/exclude fields, custom combinators, floating-point tolerances — all declarative."
-draft: true
+draft: false
+discussion: https://github.com/wrocpp/wrocpp.github.io/discussions/46
 ---
 
 import GodboltEmbed from '../../components/GodboltEmbed.astro';
@@ -174,7 +175,7 @@ Reflection version: zero bytes of per-type code. Opt out when you need custom lo
 
 Each struct hash becomes an unrolled sequence of `hash_combine` calls. For a struct with N fields, that's N hash-of-field calls plus N seed updates. Identical to what you'd hand-write. No reflection cost at runtime — `template for` unrolled before codegen.
 
-<GodboltEmbed id="TODOdereqhash" title="Derived hash + ordering from structure" />
+<GodboltEmbed id="43WMPKPMq" title="Derived hash + ordering from structure" />
 
 ## When not to use this
 


### PR DESCRIPTION
Same shape as PR #43 but for posts 6 (Thu 5/7) + 7 (Sat 5/9), plus social captions for both + MR4.5 testing-for-safety-2026 launch (Sat 5/16). Cron guards queued separately.