### PR TITLE
feat(post-6): per-section godbolt embeds for each formatter variant

### DIFF
--- a/src/content/posts/2026-07-08-auto-formatter.mdx
+++ b/src/content/posts/2026-07-08-auto-formatter.mdx
@@ -110,6 +110,8 @@ std::println("{}", u);
 // User{name: filip, role: admin}
 ```
 
+<GodboltEmbed id="ee3sE6aEh" title="Aggregate formatter + enum-name formatter (clang-p2996)" />
+
 ### Optionals
 
 ```cpp
@@ -121,6 +123,8 @@ std::println("{}", u);
 ```
 
 `std::formatter<std::optional<T>>` needs a small template too (C++26 adds it in the standard library; add yours if shipping earlier).
+
+<GodboltEmbed id="oKP46KGqE" title="Optional fields print as value or 'nullopt' (clang-p2996)" />
 
 ### Sensitive fields
 
@@ -139,6 +143,8 @@ std::println("{}", u);
 
 The check is a `template for` + `if constexpr` exactly like the JSON serializer's skip annotation.
 
+<GodboltEmbed id="4sYzh8bnc" title="Skip annotation redacts sensitive fields (clang-p2996)" />
+
 ## Custom formatters for specific types
 
 When you want something other than the default, provide a regular non-reflective `std::formatter` specialisation:
@@ -154,6 +160,8 @@ struct std::formatter<MyDate> {
 ```
 
 The generic aggregate specialisation is more constrained (`is_aggregate_v<T>` + not an array), so it loses to your explicit one. Customise where you need to; let the default handle the rest.
+
+<GodboltEmbed id="qG9h8x8Gh" title="Explicit per-type formatter coexists with generic aggregate (clang-p2996)" />
 
 ## Deep hierarchies
 
@@ -187,7 +195,7 @@ Our version: no field limit, preserves names, `is_aggregate_v` constraint produc
 
 The `{fmt}` library has `FMT_FORMAT_AS(T, ...)` macros for teaching `fmt::format` how to print a type. They're great but per-type. Reflection replaces them with a single partial specialisation.
 
-<GodboltEmbed id="Wbeq4oEP5" title="reflect_print — auto std::formatter for any aggregate" />
+<GodboltEmbed id="Wbeq4oEP5" title="reflect_print -- the core 30 lines (gcc 16.1)" />
 
 ## What's next
 

--- a/src/data/godbolt-permalinks.yml
+++ b/src/data/godbolt-permalinks.yml
@@ -107,6 +107,30 @@ auto-formatter:
     gcc_id: Wbeq4oEP5
     gcc_url: https://godbolt.org/z/Wbeq4oEP5
     gcc_expected_output: 'User{name: Filip, age: 40, admin: true, home: Address{city: Warsaw, postal_code: 12345}}'
+  formatter_custom:
+    title: Formatter custom
+    id: qG9h8x8Gh
+    url: https://godbolt.org/z/qG9h8x8Gh
+    expected_output: '2026-05-14
+
+      Event{name: C++26 ratification, when: 2026-03-28}'
+  formatter_enum:
+    title: Formatter enum
+    id: ee3sE6aEh
+    url: https://godbolt.org/z/ee3sE6aEh
+    expected_output: 'User{name: filip, role: admin}'
+  formatter_optional:
+    title: Formatter optional
+    id: oKP46KGqE
+    url: https://godbolt.org/z/oKP46KGqE
+    expected_output: 'User{name: filip, age: nullopt}
+
+      User{name: alice, age: 42}'
+  formatter_skip:
+    title: Formatter skip
+    id: 4sYzh8bnc
+    url: https://godbolt.org/z/4sYzh8bnc
+    expected_output: 'User{name: filip, password_hash: <redacted>}'
 derive-eq-hash:
   hash_demo:
     title: Hash demo


### PR DESCRIPTION
Each in-text demo (enum, optional, skip annotation, custom formatter) gets its own runnable godbolt embed. Companion c++26 PR adds 4 new self-contained .cpp files.