### PR TITLE
feat(post-12): two additional cli examples (bitflag + type-axis) embedded in design sidebar

### DIFF
--- a/src/content/posts/2026-09-30-clap-for-cpp.mdx
+++ b/src/content/posts/2026-09-30-clap-for-cpp.mdx
@@ -261,6 +261,10 @@ struct Args {
 };
 ```
 
+The bitflag pattern actually works as advertised — the demo below walks the struct and prints which modifier bits each field carries:
+
+<GodboltEmbed id="rsaqjGjPE" title="enum-class bitflag annotations -- modifier set per field" />
+
 Bitflags **win** when the modifier set is closed, the combinations recur, and the consumer wants the whole mask as a value -- the canonical examples are `std::ios::fmtflags` and `std::filesystem::perms`. They **lose** on:
 
 - **Documentation surface** — each combination is implicit; clap-rs's most-cited derive pain ([discussion #4090](https://github.com/clap-rs/clap/discussions/4090)) is exactly this open-endedness.
@@ -269,6 +273,10 @@ Bitflags **win** when the modifier set is closed, the combinations recur, and th
 - **Invalid-combination rejection** — overload resolution + `static_assert` can reject impossible tag pairs at compile time; every bit combination is syntactically valid.
 
 And there's a **third orthogonal axis you should use first: the type signature.** `std::optional<int> count` says "optional" without any annotation; `std::vector<std::string> includes` says "repeatable". Clap-rs's `Option<T>` / `Vec<T>` convention encodes those modifiers in the type system, not the attribute system, leaving the annotation surface for the genuinely declarative parts (flag names, defaults, env-var bindings). The C++ version follows the same lesson — your annotation taxonomy should cover only what the type system can't say.
+
+The demo below runs a `shape_of<T>()` consteval helper across the fields of an `Args` struct and prints the per-field shape derived from the type alone — no annotations involved:
+
+<GodboltEmbed id="o5dM6z79c" title="Type-signature as third axis -- optional/repeatable/required from the type" />
 
 ## What about CLI11 / cxxopts?
 

--- a/src/data/godbolt-permalinks.yml
+++ b/src/data/godbolt-permalinks.yml
@@ -369,11 +369,8 @@ profiling-cpp-2026:
     title: Auto-trace every annotated method (clang-p2996)
     id: 1cbnKGfW3
     url: https://godbolt.org/z/1cbnKGfW3
-    expected_output: |-
-      == span log (3 entries) ==
-        draw            <ns> ns
-        flush           <ns> ns
-        draw            <ns> ns
+    expected_output: "== span log (3 entries) ==\n  draw            <ns> ns\n  flush           <ns> ns\n  draw           \
+      \ <ns> ns"
 memory-safety-cpp26-and-beyond:
   reflect_profile:
     title: Reflection-driven basic safety profile (clang-p2996)
@@ -430,6 +427,19 @@ clap-for-cpp:
     id: bas17xKqj
     url: https://godbolt.org/z/bas17xKqj
     expected_output: verbose=true count=5 input=input.txt
+  cli_bitflag:
+    title: Cli bitflag
+    id: rsaqjGjPE
+    url: https://godbolt.org/z/rsaqjGjPE
+    expected_output: "Args fields with their modifier masks:\n  --input        required \n  --api_token    required env \n\
+      \  --debug        hidden \n  --include      repeatable \n  --verbose      (none)"
+  cli_type_axis:
+    title: Cli type axis
+    id: o5dM6z79c
+    url: https://godbolt.org/z/o5dM6z79c
+    expected_output: "Args fields, shape derived from type alone (no annotations):\n  input       required   (must appear)\n\
+      \  count       optional   (default = nullopt)\n  output      optional   (default = nullopt)\n  includes    repeatable\
+      \ (default = empty)\n  verbose     required   (must appear)"
 tiny-orm:
   sql_gen:
     title: Sql gen


### PR DESCRIPTION
Backs the design-alternatives sidebar with live godbolt demos: enum-class bitflag annotations + type-signature-as-modifier-axis. Examples in cpp26 repo PR also opened separately.