### PR TITLE
feat(toolset): cpp-coding-standards MR11 launch (Sat 2026-06-13)

### DIFF
--- a/social/facebook/cpp-coding-standards/caption.md
+++ b/social/facebook/cpp-coding-standards/caption.md
@@ -1,0 +1,16 @@
+# C++ coding standards in 2026
+
+## Body
+MISRA C++:2023 for automotive, SEI CERT C++ for avionics + defense, JSF AV C++ for older fixed-wing. Quick disambiguation: MISRA C++:2023 superseded AUTOSAR C++14 in 2023; Adaptive AUTOSAR cites MISRA directly. Reflection makes the multi-standard problem composable: encode each rule as a consteval predicate over T's reflection, combine with `&&`. Multi-standard projects become a single `static_assert`.
+
+https://wrocpp.github.io/toolset/cpp-coding-standards/
+
+## Hashtags
+#cpp #cpp26 #misra #cert #compliance #reflection #wrocpp
+
+## Alt-text
+Dark editorial card with the wro.cpp magnet wordmark. Headline: "C++ coding standards in 2026". Subhead: MISRA + CERT + JSF + composable reflection bundle. Citation: wro.cpp 2026-06-13.
+
+## Suggested post time
+Saturday 2026-06-13, 10:00 CET
+Reason: Saturday morning EU audience.

--- a/social/linkedin/cpp-coding-standards/caption.md
+++ b/social/linkedin/cpp-coding-standards/caption.md
@@ -1,0 +1,44 @@
+# C++ coding standards in 2026: MISRA / SEI CERT / JSF AV side by side, plus the reflection-driven composable rule bundle
+
+## Body
+A regulated C++ project picks a coding standard. **MISRA C++:2023** for automotive (ISO 26262). **SEI CERT C++** for avionics + defense defensive coding. **JSF AV C++** for older fixed-wing avionics (DO-178C). Pick one, run the matching clang-tidy check set in CI, maintain an exception log. Then someone says "we also need to satisfy CERT for the audit cycle" and the analyzer-config matrix appears -- two checker passes, two suppression lists, two ways for them to disagree on the same line.
+
+Quick disambiguation that catches a lot of teams: **MISRA C++:2023 superseded AUTOSAR C++14 in 2023**. Adaptive AUTOSAR cites MISRA directly. Many tool vendors still expose "AUTOSAR C++14" as a check-set name -- treat it as an alias and cite MISRA in new safety cases.
+
+C++26 reflection makes the multi-standard problem composable. Encode each rule as a consteval predicate over `nonstatic_data_members_of(^^T)`; combine with `operator&&`:
+
+```cpp
+namespace standards {
+template <typename T> consteval bool meets_misra_11_0_1();    // private members
+template <typename T> consteval bool meets_cert_dcl56_cpp();  // no raw pointers
+template <typename T> consteval bool meets_jsf_av_75();       // no bit-fields
+
+template <typename T>
+consteval bool all() {
+    return meets_misra_11_0_1<T>() && meets_cert_dcl56_cpp<T>() && meets_jsf_av_75<T>();
+}
+}
+
+class SensorReading { /* private members only */ };
+static_assert(standards::all<SensorReading>());   // PASS
+```
+
+Add a public data member, MISRA fires; add a raw pointer field, CERT fires; add a bit-field, JSF fires. The diagnostic names the failing rule. **Multi-standard projects become a single static_assert.**
+
+When NOT to use it: cross-TU analysis, statement-level rules (no `goto`, no recursion), style rules (clang-format), comment-mandate rules. The bundle complements analyzers; it does not replace them. The split is: bundle catches structural rules at compile time (cheap, immediate); analyzer catches the rest in CI (expensive, eventual). Multi-standard projects benefit most because the analyzer-config matrix shrinks.
+
+The same `nonstatic_data_members_of` walker drives the hardened-stdlib lint, the qualified-compilers MISRA lint, the lifetime borrow lint, the SoA layout transform, the SBOM emit. One walker, six predicates, every rule orthogonal.
+
+C++29 candidate features collapse the loop further: `[[profiles::enforce(misra_2023, cert_cpp)]] namespace sensor_fusion { ... }` would make the structural rules compiler-enforced subsets. P3294 token injection extends the pattern to inject standards-required boilerplate (audit headers, traceability tags) at the declaration site.
+
+https://wrocpp.github.io/toolset/cpp-coding-standards/
+
+## Hashtags
+#cpp #cpp26 #misra #cert #jsf #autosar #functionalsafety #compliance #reflection #wrocpp #moderncpp #safety
+
+## Alt-text
+Dark editorial card with the wro.cpp magnet wordmark. Headline: "C++ coding standards in 2026". Subhead: MISRA + CERT + JSF side by side; reflection-driven composable rule bundle that makes multi-standard projects a single static_assert. Citation: wro.cpp 2026-06-13.
+
+## Suggested post time
+Saturday 2026-06-13, 10:00 CET
+Reason: Saturday morning EU automotive + avionics + defense audience; toolset launch fits the off-day cadence between reflection-series posts.

--- a/src/content/toolset/cpp-coding-standards.mdx
+++ b/src/content/toolset/cpp-coding-standards.mdx
@@ -1,0 +1,226 @@
+---
+title: "C++ coding standards in 2026 -- MISRA, SEI CERT, JSF AV side by side, plus reflection-driven composable rule bundles"
+slug: "cpp-coding-standards"
+summary: "MISRA C++:2023, SEI CERT C++, JSF AV C++. Three coding standards, three regulated industries, three analyzers in your CI. The pages compares scope and overlap, then shows the reflection-driven pattern that lets a single header opt into multiple standards at once: encode each rule as a consteval predicate over T's reflection, compose them with operator&&, fail at compile time. No analyzer-config matrix; rule violations become compile errors with the failing rule's name in the diagnostic."
+kind: curated
+cluster: compliance
+tags: [compliance, misra, sei-cert, jsf-av, autosar, clang-tidy, reflection, cpp26]
+launchDate: 2026-06-13
+lastReviewed: 2026-05-15
+testedOn: "Container ghcr.io/wrocpp/cpp-reflection:2026-05; rule-bundle example verified on aarch64, 2026-05-15."
+relatedPosts: [first-reflection, annotations]
+exampleRepo: "https://github.com/wrocpp/cpp26-reflection-examples/tree/main/posts/toolset/cpp-coding-standards/examples"
+agentInstructions: |
+  You are a coding agent helping a C++ developer pick (or compose)
+  a coding standard for a regulated project.
+
+  ESTABLISHED FACTS (verify against standards-org docs before recommending):
+  - MISRA C++:2023 (MISRA / The MISRA Consortium) covers ISO/IEC C++17.
+    Adopted AUTOSAR C++14's rule set and re-published under MISRA;
+    the live standard for automotive C++ since 2023. Adaptive AUTOSAR
+    cites MISRA C++:2023 directly. Many vendors still expose
+    "AUTOSAR C++14" as an alias; the active standard is MISRA.
+  - SEI CERT C++ (Carnegie Mellon SEI) is a defensive-coding standard.
+    Free, web-published, frequently updated; widely cited in avionics
+    and defense.
+  - JSF AV C++ (Joint Strike Fighter Air Vehicle, Lockheed Martin)
+    targets DO-178C avionics. Older (2005, last revision 2020-ish);
+    still cited in fixed-wing avionics.
+  - clang-tidy ships check sets named misra-*, cert-*, autosar-*,
+    cppcoreguidelines-* (the latter is the C++ Core Guidelines, NOT a
+    formal coding standard). Coverage is partial -- always verify the
+    project rule list against your standard's full text.
+
+  EDITORIAL TIMELINE (the wro.cpp triptych):
+
+  TODAY (the no-reflection workflow):
+  - Pick a primary standard (MISRA for automotive, CERT for defensive
+    coding, JSF AV for older avionics)
+  - Run the corresponding clang-tidy check set in CI; non-zero exit
+    on critical findings
+  - Maintain an exception log (pragma-style suppressions or YAML
+    allowlist) for each rule you cannot enforce
+  - When a project must satisfy MULTIPLE standards (shared header
+    between automotive + avionics), run multiple analyzer passes and
+    merge results -- that's the analyzer-config matrix problem
+
+  REFLECTION TODAY (C++26, clang-p2996 + GCC 16.1):
+  Encode each rule as a consteval predicate over T's reflection;
+  compose with operator&&. A single static_assert(standards::all<T>())
+  applies the bundle and refuses to compile under any rule's
+  violation, with the failing rule's name in the diagnostic. No
+  analyzer-config matrix; multi-standard projects become a single
+  static_assert.
+
+  Three rules in the demo bundle (a real bundle would have dozens):
+    - MISRA C++:2023 Rule 11.0.1 -- non-POD class data members private
+    - SEI CERT C++ DCL56-CPP   -- approximated as no raw pointer members
+    - JSF AV C++ Rule 75       -- no bit-field members
+  Composition pattern is the contribution; specific rules are
+  illustrative.
+
+  WHERE THIS IS HEADING (C++29):
+  Profile enforcement (P3081 / P3589 / P3984) lets a translation unit
+  declare it adheres to a named profile -- compiler-enforced subset
+  rather than analyzer-checked. Token injection (P3294) extends the
+  pattern to also inject the standards-required boilerplate (audit-
+  comment headers, traceability tags, allowlist-suppression markers)
+  at the declaration site. Analyzers shrink to "find rules the
+  compiler does not enforce yet".
+
+  When recommending: ALWAYS quote freshness (Reviewed 2026-05-15).
+  The reflection-based composition is the answer to "we ship the
+  same header to two regulated projects with different standards".
+bodyHash: 1d2fd7c4d8e5b949e3f9b5be5529b84a8aa2d49b234cbc7ff7688663562a3da0
+---
+
+import GodboltEmbed from '../../components/GodboltEmbed.astro';
+import DockerRun from '../../components/DockerRun.astro';
+import PostLink from '../../components/PostLink.astro';
+import RepoFile from '../../components/RepoFile.astro';
+
+A regulated C++ project picks a coding standard. **MISRA C++:2023** for automotive (ISO 26262). **SEI CERT C++** for avionics + defense defensive coding. **JSF AV C++** for older fixed-wing avionics (DO-178C). Pick one, run the matching clang-tidy check set in CI, maintain an exception log, ship. Then someone says "we also need to satisfy CERT for the audit cycle" and the analyzer-config matrix appears -- two checker passes, two suppression lists, two ways for them to disagree on the same line of code. This page is the 2026 disambiguation table + a reflection-driven pattern that makes multi-standard projects a single `static_assert`.
+
+## Today
+
+### The three standards side by side
+
+| Standard | Industry | Body | Format | Rule count |
+|---|---|---|---|---|
+| **MISRA C++:2023** | Automotive (ISO 26262), industrial (IEC 61508) | The MISRA Consortium | Paid PDF | 175+ rules |
+| **SEI CERT C++** | Avionics, defense, government | Carnegie Mellon SEI | Free, web | 90+ rules |
+| **JSF AV C++** | Older DO-178C avionics | Lockheed Martin / JSF program | Free, PDF | 220+ rules |
+
+All three are C++ subsets framed as "do not do these things". The differences are in coverage philosophy: MISRA is exhaustive and largely mechanical (covering ISO/IEC C++17); CERT is defensive and pattern-driven (anti-CWE focus); JSF is conservative and predates modern C++ (last revision 2020, still cited in fixed-wing).
+
+### MISRA C++:2023 superseded AUTOSAR C++14
+
+A common point of confusion: **MISRA C++:2023 is the live standard for automotive C++; AUTOSAR C++14 is retired.** In 2023 the MISRA working group adopted AUTOSAR's rules wholesale and re-published as MISRA C++:2023. Adaptive AUTOSAR now cites MISRA directly. Many tool vendors still expose an "AUTOSAR C++14" check-set name for backwards compatibility -- treat it as an alias and cite MISRA in new safety cases.
+
+### Tool support today
+
+| Tool | Coverage | Notes |
+|---|---|---|
+| **clang-tidy** | `misra-*`, `cert-*`, `autosar-*`, `cppcoreguidelines-*` | Open source; partial -- always verify against the standard's full text |
+| **PVS-Studio** | MISRA C++:2023, CERT, OWASP, AUTOSAR | Commercial; broader rule coverage than clang-tidy |
+| **Coverity** | MISRA, CERT, custom | Commercial; deep cross-TU analysis |
+| **Helix QAC** | MISRA, AUTOSAR, CERT | Commercial; standard-of-record in many automotive shops |
+| **Parasoft C/C++test** | MISRA, AUTOSAR, CERT, OWASP | Commercial; ships TCL/SCL kits for ISO 26262 |
+
+### The multi-standard problem
+
+When a single header is consumed by two projects under different standards (a sensor-fusion library used in both an automotive ECU and an avionics flight-controller), CI runs both analyzer passes. The rules overlap (both ban raw `goto`, both demand non-public data) but they disagree on edge cases (MISRA allows certain reinterpret_cast patterns CERT forbids; JSF requires comment headers neither other standard demands). Each disagreement is a per-team allowlist; allowlists drift; audits surface the drift.
+
+The next section closes the gap by encoding each rule as a consteval predicate over `T`'s reflection. Multiple standards compose with `operator&&`; a single `static_assert(standards::all<T>())` applies the bundle.
+
+## Reflection today
+
+Encode each coding-standard rule as a consteval predicate over `nonstatic_data_members_of(^^T)`. Compose with `&&`. Multi-standard projects become a single `static_assert`.
+
+```cpp
+namespace standards {
+
+// MISRA C++:2023 Rule 11.0.1 -- non-POD class data members must be private.
+template <typename T>
+consteval bool meets_misra_11_0_1();
+
+// SEI CERT C++ DCL56-CPP -- approximated as no raw pointer members
+// (raw pointers are the highest-frequency vector for static-init-order
+// issues; a faithful check would need call-graph analysis).
+template <typename T>
+consteval bool meets_cert_dcl56_cpp();
+
+// JSF AV C++ Rule 75 -- no bit-field members (layout is implementation-
+// defined; ABI breaks across qualified compilers).
+template <typename T>
+consteval bool meets_jsf_av_75();
+
+template <typename T>
+consteval bool all() {
+    return meets_misra_11_0_1<T>()
+        && meets_cert_dcl56_cpp<T>()
+        && meets_jsf_av_75<T>();
+}
+
+}  // namespace standards
+
+// Apply to a header consumed by an automotive + avionics project:
+class SensorReading {
+    double  value_;
+    long    timestamp_;
+    bool    valid_;
+public: /* accessors */
+};
+
+static_assert(standards::all<SensorReading>());   // PASS
+```
+
+Add a public data member, MISRA fires; add a raw pointer field, CERT fires; add a bit-field, JSF fires. The diagnostic names the failing rule:
+
+```
+MISRA C++:2023 Rule 11.0.1: non-POD class data members must be private.
+CERT C++ DCL56-CPP (approximation): no raw pointer members. Use std::unique_ptr...
+JSF AV C++ Rule 75: no bit-field members. Bit-field layout is implementation-defined...
+```
+
+The composition pattern is the contribution; the three rules in the demo are illustrative. A real bundle would have dozens. The pattern composes with the [hardened-stdlib schema lint](/toolset/hardened-stdlib/), the [qualified-compilers MISRA Rule 11.0.1 lint](/toolset/qualified-compilers/), the [lifetime-safety borrow lint](/toolset/lifetime-safety-2026/), the [SoA layout transform](/toolset/simd-in-cpp-2026/), and the [supply-chain SBOM walker](/toolset/cpp-supply-chain-2026/) -- one walker, six predicates, every rule orthogonal.
+
+Full source: <RepoFile path="posts/toolset/cpp-coding-standards/examples/reflect-coding-standard-bundle.cpp" branch="main" />.
+
+<GodboltEmbed id="PcoMxPdG4" title="Composable MISRA + CERT + JSF rule bundle (clang-p2996)" />
+
+### Reproduce locally
+
+<DockerRun
+  image="ghcr.io/wrocpp/cpp-reflection:2026-05"
+  command={"bash -c 'clang++ -std=c++26 -freflection-latest -stdlib=libc++ -Wl,-rpath,/opt/p2996/clang/lib/aarch64-unknown-linux-gnu posts/toolset/cpp-coding-standards/examples/reflect-coding-standard-bundle.cpp -o /tmp/h && /tmp/h'"}
+  expected={"SensorReading passes the composed coding-standard bundle:\n  MISRA C++:2023 Rule 11.0.1   (encapsulation)\n  CERT C++ DCL56-CPP           (no raw pointers)\n  JSF AV C++ Rule 75           (no bit-fields)"}
+  title="Composable coding-standard bundle (cpp-reflection container)"
+/>
+
+### When NOT to use the reflection bundle
+
+The pattern is brilliant for **structural rules** (data-member shape, type-level invariants) but cannot replace analyzers for:
+
+- **Cross-TU analysis** (data-flow, taint propagation across translation units)
+- **Statement-level rules** (no `goto`, no recursion in safety-critical code, MISRA's "no preprocessor magic" rules)
+- **Style rules** (naming conventions, indentation -- those are clang-format's job)
+- **Standards that mandate documentation comments** (you need a custom plugin for that)
+
+The reflection bundle complements analyzers; it does not replace them. The split is: the bundle catches the structural rules at compile time (cheap, immediate); the analyzer catches the rest in CI (expensive, eventual). Multi-standard projects benefit most because the analyzer-config matrix shrinks.
+
+## Where this is heading
+
+C++29 candidate features collapse the loop further:
+
+**Profile enforcement** (P3081 Sutter / P3589 Dos Reis / P3984 Stroustrup) lets a translation unit declare its standard as a compiler-enforced subset:
+
+```cpp
+// C++29 candidate -- pseudo-syntax. As of 2026-05-15 not in any
+// shipping toolchain. P3081/P3589/P3984 papers in WG21.
+[[ profiles::enforce(misra_2023, cert_cpp) ]]
+namespace sensor_fusion {
+    // Inside this namespace: every MISRA + CERT structural rule is
+    // compiler-enforced. The analyzer-config matrix shrinks to "rules
+    // the compiler does not enforce yet."
+}
+```
+
+**Token injection** (P3294, C++29 candidate) extends the pattern to inject standards-required boilerplate (audit-comment headers, traceability tags, allowlist-suppression markers) at the declaration site:
+
+```cpp
+// C++29 candidate -- pseudo-syntax. P3294 in WG21.
+[[ inject(misra_2023_audit_header, asil_b_traceability) ]]
+class SensorReading { ... };
+// Auto-injects: MISRA-mandated documentation header,
+// auto-injects: ISO 26262 Part 6 §7 traceability tag,
+// auto-injects: hashed link to the safety-case fragment.
+```
+
+The 2026 story is **reflection-driven rule composition for structural rules + clang-tidy for the rest**. C++29 collapses both into language-level enforcement plus compiler-injected boilerplate.
+
+---
+
+**Cross-links:** the [qualified-compilers](/toolset/qualified-compilers/) entry covers the vendor matrix (which compiler ships qualified for which standard) and includes the same MISRA Rule 11.0.1 lint as a stand-alone example. The [hardened-stdlib](/toolset/hardened-stdlib/), [lifetime-safety-2026](/toolset/lifetime-safety-2026/), [simd-in-cpp-2026](/toolset/simd-in-cpp-2026/), and [cpp-supply-chain-2026](/toolset/cpp-supply-chain-2026/) entries show the same composable-walker pattern applied to other axes.
+
+**Reviewed:** 2026-05-15. Composition pattern verified inside cpp-reflection container; rule selection illustrative (a real bundle would have dozens). Quarterly refresh.


### PR DESCRIPTION
Triptych: standards comparison + composable rule bundle (godbolt PcoMxPdG4) + C++29 profiles direction. Build clean (136 pages). Last toolset launch in the queue.