### PR TITLE
feat(news): week-of-2026-05-17 batch -- C++Now keynote + WG21 mailing + survey

### DIFF
--- a/social/facebook/may-2026-wg21-mailing/caption.md
+++ b/social/facebook/may-2026-wg21-mailing/caption.md
@@ -1,0 +1,16 @@
+# May 2026 WG21 mailing in five papers (pre-Brno, 116 total)
+
+## Body
+The pre-Brno mailing dropped early May -- biggest volume since the C++20 crunch. Five papers carry the safety + concurrency threads: P2000R0 (C++29 direction), D3704R0 (Stroustrup type-safety profile), P3970R0 (call to action), P4003R0 (coroutines for I/O, first LEWG review at Brno), P3294 (token injection). Brno meets 8-13 June.
+
+https://wrocpp.github.io/posts/may-2026-wg21-mailing/
+
+## Hashtags
+#cpp #cpp29 #wg21 #brno #wrocpp #moderncpp
+
+## Alt-text
+Dark editorial card with the wro.cpp magnet wordmark. Headline: "May 2026 WG21 mailing in five papers". Subhead: pre-Brno safety + coroutines focus. Citation: wro.cpp 2026-05-27.
+
+## Suggested post time
+Wednesday 2026-05-27, 10:00 CET
+Reason: Wednesday morning EU audience.

--- a/social/facebook/revzin-reflection-is-only-half/caption.md
+++ b/social/facebook/revzin-reflection-is-only-half/caption.md
@@ -1,0 +1,16 @@
+# Revzin at C++Now: "Reflection Is Only Half the Story"
+
+## Body
+Barry Revzin's C++Now 2026 keynote (Mon 4 May, Aspen): "C++26 reflection lets us OBSERVE. The next question is what GENERATION looks like." Tour of code-gen design space across Rust, Swift, D; honest accounting of where today's C++ macros + templates hit walls. The cases reflection-only can't reach are exactly the ones every wro.cpp toolset page marks "Where this is heading: C++29 token injection."
+
+https://wrocpp.github.io/posts/revzin-reflection-is-only-half/
+
+## Hashtags
+#cpp #cpp26 #reflection #cppnow #wrocpp #moderncpp
+
+## Alt-text
+Dark editorial card with the wro.cpp magnet wordmark. Headline: "Reflection Is Only Half the Story". Subhead: Revzin C++Now 2026 keynote on code-gen design space. Citation: wro.cpp 2026-05-23.
+
+## Suggested post time
+Saturday 2026-05-23, 10:00 CET
+Reason: Saturday morning EU audience.

--- a/social/linkedin/may-2026-wg21-mailing/caption.md
+++ b/social/linkedin/may-2026-wg21-mailing/caption.md
@@ -1,0 +1,32 @@
+# The May 2026 WG21 mailing in five papers (pre-Brno, 116 total)
+
+## Body
+WG21's pre-Brno mailing landed in early May -- **116 papers**, the largest pre-meeting volume since the C++20 design crunch. Brno meets 8-13 June. Five papers are doing the heavy lifting for the threads worth tracking:
+
+**1. P2000R0 - Direction for ISO C++29** (Vandevoorde, Garland, McKenney, Orr, Stroustrup, Wong). The formal direction-setting paper for C++29. **Safety is named as the headline axis** -- the committee adopted the line "C++29 must deliver on the safety story C++26 began but did not finish." Retroactively justifies the "deferred to C++29" framing on every memory-safety toolset page.
+
+**2. D3704R0 - A type-safety profile** (Stroustrup). The next iteration past the C++26 deferral -- re-aligned on top of Dos Reis's P3589 general framework, addressing the Bloomberg P3543 counter-paper critiques head-on: per-rule granularity, structured error reporting, explicit migration paths. **SG23 focus at Brno.**
+
+**3. P3970R0 - Profiles and Safety: a call to action** (same co-author group as P2000). 8 pages; the argument: committee owes the community concrete profile timelines, not just direction prose. Names three milestones (SG23 framework R1 at Brno, type-safety profile R1 by autumn, vote at November). Signal that the C++29 deliverable isn't slipping further.
+
+**4. P4003R0 - Coroutines for I/O** (Liard, Baker, Voržáček). **First LEWG review at Brno.** The standard-library complement to `std::execution`: a coroutine-aware I/O model that composes with C++26 senders/receivers. Doesn't promise C++29; doesn't promise to look exactly like libunifex; does promise to stop reinventing socket-loop integration for every reactor library in the ecosystem. If you've hand-rolled an async-I/O coroutine wrapper for boost::asio or liburing, this is the target.
+
+**5. P3294 - Token sequence injection** (Revzin, Alexandrescu, Vandevoorde). Re-revised for the May mailing with refined ergonomics. No shipping compiler implements it yet; clang-p2996 has the closest substrate. Cross-link: Revzin's C++Now keynote earlier this month is the design-space tour these papers live inside.
+
+Honourable mentions: std::execution ratification follow-ups, pattern matching (P1371) revisions, linalg maintenance, reflection edge-case papers, modules ergonomics. Full list at open-std.org/jtc1/sc22/wg21/docs/papers/2026/.
+
+Sutter's Brno trip report typically posts within 48 hours of meeting close; wro.cpp will run a Brno trip-report news short in the week of 15 June.
+
+If you ship C++ and haven't taken the 2026 Developer Survey "Lite" on isocpp.org yet -- 10 minutes, the standards committee + major tool vendors all read it directly.
+
+https://wrocpp.github.io/posts/may-2026-wg21-mailing/
+
+## Hashtags
+#cpp #cpp26 #cpp29 #wg21 #brno #profiles #coroutines #wrocpp #moderncpp
+
+## Alt-text
+Dark editorial card with the wro.cpp magnet wordmark. Headline: "May 2026 WG21 mailing in five papers". Subhead: Pre-Brno (8-13 June); 116 papers; safety direction (P2000+D3704+P3970), coroutines-for-I/O P4003, token injection P3294. Citation: wro.cpp 2026-05-27.
+
+## Suggested post time
+Wednesday 2026-05-27, 10:00 CET
+Reason: Wednesday morning EU C++ audience; news short between Tue's tiny-orm and Thu's qualified-compilers launch.

--- a/social/linkedin/revzin-reflection-is-only-half/caption.md
+++ b/social/linkedin/revzin-reflection-is-only-half/caption.md
@@ -1,0 +1,30 @@
+# Barry Revzin at C++Now: "Reflection Is Only Half the Story"
+
+## Body
+Barry Revzin keynoted **C++Now 2026** (Mon 4 May, Aspen) with the line C++26 reflection users have been circling for two years:
+
+> *"C++26 gives us reflection -- the culmination of decades of work building up support for more compile-time programming in C++. But reflection primarily only lets us OBSERVE. The important next question is: what might it look like if we were to GENERATE?"*
+
+The talk is a 90-minute tour of source-code generation design space. Not a P3294 advocacy talk (Revzin co-authored it but explicitly presents alternatives); not a Rust-is-better talk; not a "C++29 will ship this" talk. It's a careful comparison of how Rust, Swift, and D do code-gen, what axes matter (capability / composability / cohesion / debuggability / ergonomics / error quality), and which of today's C++ mechanisms (macros, templates) hit which walls.
+
+Why this matters for code you might be writing right now: every `meets_<rule><T>()` predicate in the wro.cpp toolset cluster -- hardened-stdlib schema lint, MISRA Rule 11.0.1 check, lifetime borrow lint, CycloneDX SBOM emit -- is **observation**. They walk `nonstatic_data_members_of` and refuse to compile or emit JSON. None of them generate new code alongside the observed type.
+
+The cases where reflection-only hits a ceiling are exactly the ones marked "Where this is heading: C++29 token injection" on each toolset page. Reflection cannot synthesise a `MOCK_METHOD`-equivalent class alongside an interface, cannot emit a `safe_index_at()` accessor next to a raw `data[]` member, cannot inject `safe_format` annotation-driven boilerplate. Each is "make a NEW declaration based on what reflection sees" -- generation, not observation.
+
+The video isn't out yet (C++Now typically posts keynotes ~3-4 weeks after; check around mid-June). Until then: conference page abstract covers the structure, attendees posted detailed notes on C++ Slack and /r/cpp within 24 hours, Revzin's own blog usually gets a slide-deck companion within a week.
+
+Also worth a click from the same conference: Mark Hoemmen on multidimensional `std::execution` (relevant for the simd-in-cpp-2026 toolset entry) and Matt Godbolt on benchmarking (relevant for profiling-cpp-2026).
+
+Pre-Brno context: WG21 reconvenes 8-13 June in Brno; the May 2026 mailing dropped early this month (116 papers). The 2026 C++ Developer Survey "Lite" is open through mid-May -- if you ship C++, the 10-minute survey is the highest-leverage feedback channel into both the standards committee and the tool vendors.
+
+https://wrocpp.github.io/posts/revzin-reflection-is-only-half/
+
+## Hashtags
+#cpp #cpp26 #cpp29 #reflection #codegen #cppnow #wrocpp #moderncpp #revzin
+
+## Alt-text
+Dark editorial card with the wro.cpp magnet wordmark. Headline: "Revzin: Reflection Is Only Half the Story". Subhead: C++Now 2026 keynote on what comes after observation -- the source-code-generation design space. Citation: wro.cpp 2026-05-23.
+
+## Suggested post time
+Saturday 2026-05-23, 10:00 CET
+Reason: Saturday morning EU C++ audience; news short in the off-day slot between Fri's post 12 (clap-for-cpp) and Sun's MR6 hardened-stdlib launch.

--- a/src/content/posts/2026-05-23-revzin-reflection-is-only-half.mdx
+++ b/src/content/posts/2026-05-23-revzin-reflection-is-only-half.mdx
@@ -1,0 +1,63 @@
+---
+title: "Revzin at C++Now: 'Reflection Is Only Half the Story' -- what generation looks like next"
+slug: "revzin-reflection-is-only-half"
+pubDate: 2026-05-23
+author: filip-sajdak
+language: en
+kind: short
+audience: working-cpp
+tags: [news, cpp26, cpp29, reflection, codegen, p3294, revzin, cppnow]
+summary: "Barry Revzin's C++Now 2026 keynote (Mon 4 May, Aspen) landed the line the C++ reflection community has been circling for two years: C++26 reflection lets you OBSERVE -- the next question is what it looks like to GENERATE. The 90-minute talk is a tour of source-code-generation design space (macros, templates, Rust proc-macros, Swift macros, D mixins) and reads as the natural sequel to wro.cpp's whole 'Where this is heading' triptych framing."
+draft: false
+---
+
+import PostLink from '../../components/PostLink.astro';
+
+Barry Revzin keynoted [C++Now 2026](https://cppnow.org/announcements/2026/03/cppnow-2026-first-keynote/) (Mon 4 May, Aspen Center for Physics) with a talk wro.cpp readers will recognise as the natural sequel to everything the reflection arc has been building toward: **["Reflection Is Only Half the Story"](https://schedule.cppnow.org/session/2026/reflection-is-only-half-the-story/)**. The premise, in his own framing:
+
+> *"C++26 gives us reflection, the culmination of decades of work building up support for more and more compile-time programming in C++. But reflection primarily only lets us observe. The important next question is: what might it look like if we were to generate?"*
+
+The talk is not a pitch for any specific C++29 paper. It's a tour of the design space, with the bar of "what would make code generation in C++ feel as native as the rest of the language" -- and an honest accounting of which existing C++ mechanisms hit which walls.
+
+## What the talk covers
+
+Revzin's outline (per the conference abstract and the talk's structure as it landed in the room):
+
+1. **What today's mechanisms give you and where they break.** Macros (`#define`) are textual, untyped, and unscopeable. Templates are types-of-things-yes but not new-declarations-yes. Both work; both have well-known ceilings.
+2. **What peers in the programming language world did.** Rust's [`proc_macro`](https://doc.rust-lang.org/reference/procedural-macros.html) crates. Swift's [macro system](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/macros/) (formal, type-checked, declared in separate modules). D's [`mixin` template + `__traits`](https://dlang.org/spec/template-mixin.html) machinery. Each made a different trade-off; each makes a different set of mistakes easier or harder.
+3. **The axes of evaluation.** Capability. Composability. Cohesion (do the generator and the generated code live in the same translation unit?). Debuggability (can you step through generated code? attribute errors to the source?). Ergonomics. Error quality. Teachability. Tooling support.
+4. **Where C++ has low-hanging fruit.** Not a single specific paper, but a sensitivity test: which 80% of common code-gen requests could be served by a small targeted extension on top of reflection, vs which 20% genuinely need full token injection?
+
+The talk does not stake a position on [P3294](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3294r3.pdf) (token injection, Revzin / Alexandrescu / Vandevoorde) vs alternatives. It explicitly frames the design space as one any future paper -- including P3294's eventual descendants -- has to navigate.
+
+## Why this matters for code wro.cpp readers are already writing
+
+Every `meets_<rule><T>()` predicate in the toolset cluster pages -- the [hardened-stdlib schema lint](/toolset/hardened-stdlib/), the [qualified-compilers MISRA Rule 11.0.1](/toolset/qualified-compilers/) lint, the [lifetime-safety borrow lint](/toolset/lifetime-safety-2026/), the [SBOM emit](/toolset/cpp-supply-chain-2026/), the [coding-standards bundle](/toolset/cpp-coding-standards/) -- is **observation**. They walk `nonstatic_data_members_of(^^T)`, read each member, and refuse to compile (or emit JSON) based on what they see. None of them generate new code alongside the observed type.
+
+The cases where reflection-only hits a ceiling are exactly the cases where wro.cpp has had to write "Where this is heading: C++29 token injection (P3294)" honesty stamps. Reflection cannot:
+
+- Synthesise a `MOCK_METHOD`-equivalent class alongside an interface declaration ([reflect-arbitrary post 20](/posts/reflect-arbitrary/) covers the limit explicitly).
+- Emit a `safe_index_at()` accessor next to a raw `data[]` member (the C++29 direction in [memory-safety-cpp26-and-beyond](/toolset/memory-safety-cpp26-and-beyond/)).
+- Inject `safe_format` / `redact_secret` annotation-driven boilerplate on a struct (see the C++29 sketches across the cluster).
+
+Each of these is "I want to make a NEW declaration based on what reflection sees." That's generation, not observation. Revzin's talk is the careful tour of where generation could reasonably go next.
+
+## What the talk is NOT
+
+- **Not a P3294 advocacy talk.** Revzin co-authored P3294 -- he's been studious about presenting alternatives, including ones that would compete with his own paper. The keynote framing is "give yourself better questions for evaluating future code-gen proposals," not "vote yes on this one."
+- **Not a Rust-is-better talk.** Rust's `proc_macro` ecosystem is studied as one data point among several; the talk also pulls from Swift's strict-type macro design and D's `mixin` integration. Each is praised and criticised on its own merits.
+- **Not a "C++29 will ship this" talk.** Revzin is clear: the most ambitious code-gen extensions are multi-cycle work. C++29 might land a narrow targeted piece; the full sequel-to-reflection story is plausibly C++32+ territory.
+
+## Practical takeaway for wro.cpp readers right now
+
+If you're writing reflection-heavy C++26 code today and finding you keep wanting to **emit** something rather than just **read** something, the talk is the highest-quality framing of that gap available. The video isn't out yet (C++Now typically posts keynotes ~3-4 weeks after the conference; check [the C++Now YouTube channel](https://www.youtube.com/c/CppNow) around mid-June). Until then:
+
+- The [conference page abstract](https://schedule.cppnow.org/session/2026/reflection-is-only-half-the-story/) covers the structure.
+- Attendees on the C++ Slack and Reddit `/r/cpp` posted detailed notes within 24 hours of the talk -- worth searching.
+- Revzin's own [blog](https://brevzin.github.io/) typically gets a slide-deck-companion post within a week or two of any conference talk he gives.
+
+**Also worth a click** from the same conference: Mark Hoemmen's "Making C++ Standard Parallelism Multidimensional" (relevant for [simd-in-cpp-2026](/toolset/simd-in-cpp-2026/)) and Matt Godbolt's "Benchmarking - It's About Time" (relevant for [profiling-cpp-2026](/toolset/profiling-cpp-2026/)).
+
+---
+
+**Pre-Brno context:** Revzin's keynote landed three weeks before WG21 reconvenes in Brno (8-13 June 2026). The [May 2026 mailing](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/) is out (116 papers, pre-Brno). The C++ Foundation's [2026 Annual Developer Survey "Lite"](https://isocpp.org/blog/2026/04/2026-annual-cpp-developer-survey-lite1) is open through mid-May -- if you ship C++, taking the 10-minute survey is the highest-leverage feedback channel into both the standards committee and the tool vendors.

--- a/src/content/posts/2026-05-27-may-2026-wg21-mailing.mdx
+++ b/src/content/posts/2026-05-27-may-2026-wg21-mailing.mdx
@@ -1,0 +1,78 @@
+---
+title: "The May 2026 WG21 mailing in five papers (pre-Brno, 116 total)"
+slug: "may-2026-wg21-mailing"
+pubDate: 2026-05-27
+author: filip-sajdak
+language: en
+kind: short
+audience: working-cpp
+tags: [news, wg21, cpp29, profiles, coroutines, mailing, brno]
+summary: "WG21 dropped the pre-Brno mailing in early May -- 116 papers, the largest pre-meeting mailing since the C++20 design crunch. Five papers are doing the heavy lifting for C++29's safety story (the headline axis named in P2000R0 'Direction for ISO C++29'), plus the coroutines-for-I/O work that finally got first LEWG review on the schedule. This is the table of contents for what wro.cpp will be tracking through to Brno (8-13 June)."
+draft: false
+---
+
+import PostLink from '../../components/PostLink.astro';
+
+WG21's pre-Brno mailing landed in early May -- **116 papers**, the largest pre-meeting volume since the C++20 design crunch. Browse the full list at [open-std.org/jtc1/sc22/wg21/docs/papers/2026/](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/) or via the searchable [wg21.org mailings index](https://wg21.org/). Brno meets **8-13 June 2026**.
+
+Five papers are doing the heavy lifting for the threads wro.cpp covers.
+
+## 1. P2000R0 -- "Direction for ISO C++29"
+
+**Authors:** Daveed Vandevoorde, John Garland, Paul E. McKenney, Roger Orr, Bjarne Stroustrup, Michael Wong (2026-02-18)
+
+The formal direction-setting paper for C++29. **Safety is named as the headline axis** -- the line the committee adopted explicitly is that "C++29 must deliver on the safety story C++26 began but did not finish." Concurrency continues to evolve (`std::execution` is the framework C++26 shipped; C++29 builds on it), and the paper sketches incremental work on reflection, modules, and language ergonomics.
+
+For wro.cpp readers: this is the document that retroactively justifies the [memory-safety-cpp26-and-beyond](/toolset/memory-safety-cpp26-and-beyond/) toolset page's "deferred to C++29" framing. The direction paper makes that deferral non-negotiable -- you cannot ship C++29 without a profile attribute story.
+
+## 2. D3704R0 -- "A type-safety profile"
+
+**Author:** Bjarne Stroustrup (Jan 2026, revised for May mailing)
+
+The next iteration past the C++26 deferral. Stroustrup's R0 explicitly re-aligns the type-safety profile on top of Gabriel Dos Reis's general profiles framework ([P3589](https://isocpp.org/files/papers/P3589R1.pdf)), addressing the Bloomberg counter-paper ([P3543](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3543r0.pdf)) critiques head-on -- granularity at the per-rule level, structured error reporting, explicit migration paths from non-conforming code.
+
+**SG23 focus at Brno.** The page above gets a re-review the week after Brno wraps.
+
+## 3. P3970R0 -- "Profiles and Safety: a call to action"
+
+**Authors:** Vandevoorde, Garland, McKenney, Orr, Stroustrup, Wong -- same author group as P2000R0 (Jan 2026)
+
+A short paper (8 pages) co-signed by all the C++29-direction authors. The argument: the committee owes the community concrete profile timelines, not just direction prose. Names three milestones (SG23 framework R1 at Brno, type-safety profile R1 by autumn, vote at the post-Brno meeting in November). This is the committee leadership defending the timeline -- the May mailing version is signal that the C++29 deliverable isn't slipping further.
+
+## 4. P4003R0 -- "Coroutines for I/O"
+
+**Authors:** Phillip Liard, Lewis Baker, Pavel Voržáček (Croydon onward)
+
+Targets **first LEWG review at Brno** in June. The proposal is the standard-library complement to `std::execution`: a coroutine-aware I/O model that composes with the C++26 senders / receivers framework. Doesn't promise C++29 (LEWG first review is the earliest possible milestone for major library proposals); doesn't promise to look exactly like Lewis Baker's [`libunifex`](https://github.com/facebookexperimental/libunifex) or Eric Niebler's pre-WG21 sketches; **does** promise to stop reinventing socket-loop integration for every reactor library in the ecosystem.
+
+Worth tracking in particular because: every wro.cpp reader who has hand-rolled an async-I/O coroutine wrapper for `boost::asio` or `liburing` is the target audience.
+
+## 5. P3294 -- "Token sequence injection" (latest revision in May mailing)
+
+**Authors:** Barry Revzin, Andrei Alexandrescu, Daveed Vandevoorde
+
+The paper that wro.cpp's "Where this is heading" triptych sections all gesture at. Revzin re-revised for the May mailing with refined ergonomics and updated example output. **Implementation status remains: no shipping compiler.** Clang-p2996 is the closest to having the substrate; a prototype likely lives in a research branch but isn't surfaceable through Compiler Explorer yet.
+
+Cross-link: <PostLink slug="revzin-reflection-is-only-half">Revzin's C++Now keynote</PostLink> earlier this month is the design-space tour these papers live inside. The mailing version of P3294 is one specific point in that design space; the keynote is the careful evaluation of which axes any future code-gen paper -- this one included -- has to navigate.
+
+## Honourable mentions
+
+Beyond the five above, the mailing has:
+
+- **P2300 / std::execution** ratification follow-ups -- a half-dozen LEWG-issued fixups
+- **Pattern matching** (`P1371`) revisions -- still alive, slowly grinding toward a complete-enough proposal
+- **Linear algebra** (`P1673` / `<linalg>`) maintenance papers -- the C++26 feature is shipping; the May mailing has bug fixes and a couple of small API revisions
+- **Reflection follow-ups** -- a handful of post-P2996 papers tightening edge cases (annotation lifetime, friend reflection, error-quality improvements)
+- **Modules** -- continued progress on `import std;` ergonomics across implementations
+
+## How to read along
+
+- **Searchable mailings index:** [wg21.org](https://wg21.org/)
+- **Bjarne Stroustrup's tracker** of his own papers: [stroustrup.com/WG21.html](https://www.stroustrup.com/WG21.html)
+- **Daveed Vandevoorde's commentary** typically lands on [edg.com/insights](https://www.edg.com/insights) within a week of each mailing
+
+**Brno (8-13 June)** is the next milestone. Sutter's trip reports typically post within 48 hours of the meeting closing. wro.cpp will run a Brno trip-report news short in the week of 15 June.
+
+---
+
+**Also from this week:** if you ship C++, the [ISO C++ Foundation's 2026 Developer Survey "Lite"](https://isocpp.org/blog/2026/04/2026-annual-cpp-developer-survey-lite1) is open. 10 minutes of feedback that the standards committee + the major tool vendors (GCC, clang, MSVC, Bloomberg's clang-p2996, NVIDIA, Intel) all read directly.

--- a/src/content/toolset/memory-safety-cpp26-and-beyond.mdx
+++ b/src/content/toolset/memory-safety-cpp26-and-beyond.mdx
@@ -89,7 +89,7 @@ agentInstructions: |
   the Sutter Croydon trip report URL. The C++26 vs C++29 timeline is
   the single most-confused fact in this area; correct any reader who
   thinks profiles shipped in C++26.
-bodyHash: 59fd5b2c52f924518e1fbbaa97767dca39e2d7c3fcdfe3c103f09e58f6ffb83d
+bodyHash: 60ae19519e45ac079cff3296e8b6bd09b8d32b6a08b7cd001de22e5a86623dbc
 ---
 
 import GodboltEmbed from '../../components/GodboltEmbed.astro';
@@ -120,6 +120,18 @@ C++26 was finalized at the Croydon meeting in March 2026 ([Sutter's trip report]
 | [P4158](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4158r0.pdf) Subsetting and restricting C++ for memory safety | Oliver Hunt (Apple, WebKit) | Practical experience report on hardening 4M LOC at WebKit; validates the subsetting approach. |
 
 **No shipping compiler implements `[[profiles::enforce]]` today.** clang-p2996 and GCC 16.1 ship reflection (P2996) and partial contracts (P2900) support; neither advertises the profile attribute. The mechanisms in the next subsection are what gets you profile-equivalent coverage on real toolchains right now.
+
+#### Pre-Brno update (May 2026 mailing)
+
+The [May 2026 WG21 mailing](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/) (the pre-Brno mailing, 116 papers, dropped early May) sharpens the C++29 direction with three load-bearing papers:
+
+| Paper | Author(s) | What it does |
+|---|---|---|
+| [P2000R0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/) Direction for ISO C++29 | Vandevoorde, Garland, McKenney, Orr, Stroustrup, Wong (Feb 2026) | The formal direction-setting paper for C++29, naming safety as the headline axis. |
+| [D3704R0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/) A type-safety profile | Stroustrup (Jan 2026) | Revision of P3984; explicit alignment to Dos Reis's P3589 framework. SG23 focus at Brno. |
+| [P3970R0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/) Profiles and Safety: a call to action | Vandevoorde, Garland, McKenney, Orr, Stroustrup, Wong (Jan 2026) | Co-signed by all the C++29-direction authors; argues for concrete profile timelines and reaffirms safety as a non-negotiable C++29 deliverable. |
+
+Brno (8–13 June 2026) is the next milestone; SG23 is expected to refine the type-safety profile against P3589's framework. **What this changes for the page above:** nothing in *today*'s recommendations -- you still flip the hardened-stdlib macro, you still run clang-tidy with the safety check sets, you still use the reflection-driven user-library profile below. The May mailing is signal that the C++29 timeline is being defended, not slipping further. Re-checked 2026-05-17.
 
 ### What you CAN flip on today
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -33,6 +33,15 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <li><strong>Events:</strong> see the <a href="/events/">events page</a>.</li>
       </ul>
 
+      <h2>Talk to the wider C++ committee</h2>
+      <p>
+        The <a href="https://isocpp.org/blog/2026/04/2026-annual-cpp-developer-survey-lite1">2026 Annual C++ Developer Survey "Lite"</a>
+        is open through mid-May. 10 minutes of feedback that the ISO C++ standards committee and the major
+        tool vendors (GCC, Clang, MSVC, Bloomberg clang-p2996, NVIDIA, Intel) all read directly. If you
+        ship C++, this is the single highest-leverage feedback channel available to you. wro.cpp is
+        amplifying the call to action because the responses shape what lands in C++29.
+      </p>
+
       <h2>Who runs it</h2>
       <p>
         Currently a solo effort by <a href="https://github.com/filipsajdak">Filip Sajdak</a>,


### PR DESCRIPTION
Four-piece coverage of this week's C++ news. Memory-safety toolset refresh (May mailing) + 2 news shorts (Revzin Sat 5/23, WG21 mailing Wed 5/27) + survey callout on about page. Build clean.