### PR TITLE
chore(deploy): add 03:30 UTC third defensive trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,14 +14,21 @@ on:
   push:
     branches: [main]
   schedule:
-    # Primary daily build at 07:00 UTC. GitHub-Actions free-tier
-    # scheduled runners drift up to ~2 hr late under load, which
+    # Three staggered daily builds. GitHub-Actions free-tier scheduled
+    # runners drift up to several hours late under load, which
     # repeatedly missed Buffer fires at 08:00 UTC for posts whose
-    # `pubDate` rolled over at 00:00 UTC the same day. The defensive
-    # 05:30 UTC backup absorbs that drift so even a ~2 hr late run
-    # rebuilds before any cron guard hits at 07:45 UTC.
+    # `pubDate` rolled over at 00:00 UTC the same day. Even with the
+    # 05:30 UTC backup added in PR #79, the 2026-05-18 fire still
+    # required a manual deploy. The 03:30 UTC defensive third trigger
+    # gives ~4 hr of total drift absorption before any pre-Buffer
+    # cron guard hits at 07:45 UTC. Three runs/day stays well under
+    # the free-tier quota and is harmless when all succeed (the
+    # `concurrency: pages, cancel-in-progress: false` group below
+    # serialises them; duplicate builds get a fresh dist with the same
+    # source so the deploy is idempotent).
     - cron: '0 7 * * *'
     - cron: '30 5 * * *'
+    - cron: '30 3 * * *'
   workflow_dispatch: {}
 
 concurrency:


### PR DESCRIPTION
05:30 UTC backup wasn't enough today; adding 03:30 UTC so ~4 hr of drift absorption before pre-Buffer guards.